### PR TITLE
Prepare v0.1.1 Agent Workspace setup release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,7 +31,7 @@ dependencies = [
 
 [[package]]
 name = "agent-workspace-linux"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "gpui",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,17 +1,18 @@
 [package]
 name = "agent-workspace-linux"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "MIT"
 description = "Isolated Linux desktop workspaces for AI agents."
 readme = "README.md"
 keywords = ["mcp", "linux", "desktop", "automation", "workspace"]
 categories = ["command-line-utilities", "development-tools"]
-# Not published to crates.io: `gpui`/`gpui_platform` are git dependencies (no
-# crates.io version), which `cargo publish` rejects. Release-on-tag ships
-# prebuilt binaries via GitHub Releases (.github/workflows/release.yml) and the
-# npm wrapper. Flip this to publish and add a crates step only once gpui is
-# available on crates.io.
+# Not published to crates.io: this package still uses git dependencies
+# (`gpui` is pinned to git here, and `gpui_platform` is not available on
+# crates.io), which `cargo publish` rejects. Release-on-tag ships prebuilt
+# binaries via GitHub Releases (.github/workflows/release.yml) and the npm
+# wrapper. Flip this to publish and add a crates step once the viewer
+# dependencies are registry-backed.
 publish = false
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ It is deliberately **not** a tool for driving your actual desktop — for that, 
 
 ## Install
 
-Requires Linux. Install the runtime dependencies, then build + register in one step:
+Requires Linux. Install the runtime dependencies, then build and install in one step:
 
 ```bash
 sudo apt install xvfb openbox xdotool xauth x11-utils imagemagick xclip \
@@ -33,7 +33,7 @@ sudo apt install xvfb openbox xdotool xauth x11-utils imagemagick xclip \
 ./install.sh
 ```
 
-`./install.sh` builds the release binary, installs it to `~/.local/bin/`, installs the bundled skill, and registers the MCP server in `~/.codex/config.toml`. It is safe to rerun. See [`install.sh --help`](install.sh) for flags (`--permissions`, `--skills-dir`, `--no-skill`, `--dry-run`).
+`./install.sh` builds the release binary, installs it to `~/.local/bin/`, and installs the bundled skill to `~/.codex/skills/` by default. It is safe to rerun. Codex MCP registration is opt-in: use `--codex-configure` only for generic MCP-host workflows. In Codex for Linux, use the dedicated **Agent Workspaces** feature page to configure the backend and permission ceiling so the generic MCP settings/configuration pages stay clean. If an older install still appears in generic MCP/configuration pages, run `./install.sh --clean-codex-config` to remove the stale `agent-workspace-linux` server and tool tables. See [`install.sh --help`](install.sh) for flags (`--permissions`, `--clean-codex-config`, `--skills-dir`, `--no-skill`, `--dry-run`).
 
 ### Install with cargo (from source)
 
@@ -43,7 +43,7 @@ It builds from source straight from git — no crates.io needed. Install the sys
 # latest from main
 cargo install --git https://github.com/agent-sh/agent-workspace-linux
 # or pin a tagged release
-cargo install --git https://github.com/agent-sh/agent-workspace-linux --tag v0.1.0
+cargo install --git https://github.com/agent-sh/agent-workspace-linux --tag v0.1.1
 ```
 
 That puts `agent-workspace-linux` on your `PATH`. Unlike `install.sh`, it installs only the binary — register it with your MCP host manually (below), and copy `skills/agent-workspace-linux/` into your skills directory if you want the bundled skill.
@@ -115,7 +115,7 @@ In short: **by default the agent host owns permission**, a developer can **lock 
 
 ## The skill (progressive tool loading)
 
-The MCP exposes ~86 tools. To avoid dumping them all into the agent's context, it ships a skill at [`skills/agent-workspace-linux/SKILL.md`](skills/agent-workspace-linux/SKILL.md). Only the skill's short description stays loaded; when a task needs an isolated desktop or browser, the agent reads the skill and it routes to the right tools per phase (orient → start → observe → act → stop), loading tool schemas on demand. `./install.sh` installs it to `~/.claude/skills/` (override with `--skills-dir`).
+The MCP exposes ~86 tools. To avoid dumping them all into the agent's context, it ships a skill at [`skills/agent-workspace-linux/SKILL.md`](skills/agent-workspace-linux/SKILL.md). Only the skill's short description stays loaded; when a task needs an isolated desktop or browser, the agent reads the skill and it routes to the right tools per phase (orient → start → observe → act → stop), loading tool schemas on demand. `./install.sh` installs it to `~/.codex/skills/` by default (override with `--skills-dir`; Claude users can pass `--skills-dir ~/.claude/skills`).
 
 ## Features
 

--- a/docs/permission-model.md
+++ b/docs/permission-model.md
@@ -104,9 +104,15 @@ Possible MCP config shape:
 }
 ```
 
-`./install.sh --permissions PATH` writes this locked MCP registration for Codex
-without hand-editing `config.toml`; running `./install.sh` without that flag
-keeps the default UI-owned open registration.
+`./install.sh --permissions PATH` is an explicit opt-in path that writes this
+locked MCP registration for generic Codex MCP-host workflows without
+hand-editing `config.toml`. Running `./install.sh` without `--permissions` or
+`--codex-configure` does not edit Codex MCP config; Codex for Linux should use
+the dedicated Agent Workspaces feature page to own permission-file mutation,
+restart/reconnect, and user-visible control instead of surfacing this backend
+through the generic MCP settings page. `./install.sh --clean-codex-config`
+removes stale `agent-workspace-linux` MCP server and nested tool tables from
+older installs.
 
 Rules:
 
@@ -252,8 +258,9 @@ remain (status as of 2026-05-26):
   app configuration, PID-less arbitrary app window targeting, and
   recovery/inspection flows work at the primitive level.
   MCP-locked permission ceilings and app allowlists have a first MCP-enforced
-  slice, and `./install.sh --permissions PATH` now gives locked MCP hosts a
-  repeatable setup path without hand-editing Codex config. The CLI also has
+  slice, and `./install.sh --permissions PATH` now gives locked MCP hosts an
+  explicit setup path without hand-editing Codex config. The default installer
+  stays skill-first and leaves generic Codex MCP settings untouched. The CLI also has
   `permissions template open|closed|local` and
   `permissions validate --json PATH` so non-Codex hosts can generate and check a
   ceiling before spawning MCP. The Codex for Linux app picker now accepts both

--- a/install.sh
+++ b/install.sh
@@ -13,26 +13,32 @@ MCP_PERMISSIONS="${MCP_PERMISSIONS:-}"
 
 DRY_RUN=0
 SKIP_BUILD=0
-CONFIGURE_CODEX=1
+CONFIGURE_CODEX=0
+CLEAN_CODEX_CONFIG=0
+CODEX_MCP_CONFIG_CHANGED=0
 RUN_DOCTOR=1
 INSTALL_SKILL=1
 SKILL_NAME="agent-workspace-linux"
-SKILLS_DIR="${SKILLS_DIR:-$HOME/.claude/skills}"
+SKILLS_DIR="${SKILLS_DIR:-$CODEX_HOME/skills}"
 SKILL_SRC="$ROOT_DIR/skills/$SKILL_NAME/SKILL.md"
 
 usage() {
   cat <<USAGE
 Usage: ./install.sh [options]
 
-Build and install agent-workspace-linux, then register its MCP server in Codex.
+Build and install agent-workspace-linux plus its lightweight skill.
+Codex MCP registration is opt-in so the dedicated Codex for Linux feature page
+can own Agent Workspace configuration without polluting generic MCP settings.
 
 Options:
   --dry-run              Show what would happen without writing files.
   --skip-build           Install an already-built target/release binary.
-  --no-codex-config      Do not edit the Codex MCP config.
+  --codex-configure      Also register the MCP server in the Codex MCP config.
+  --no-codex-config      Do not edit the Codex MCP config (default).
+  --clean-codex-config   Remove existing Agent Workspace MCP entries from Codex config.
   --no-doctor            Do not run agent-workspace-linux doctor after install.
   --no-skill             Do not install the agent-workspace-linux skill.
-  --skills-dir PATH      Install the skill under PATH (default: ~/.claude/skills).
+  --skills-dir PATH      Install the skill under PATH (default: CODEX_HOME/skills).
   --prefix PATH          Install under PATH (default: ~/.local).
   --bindir PATH          Install binary into PATH (default: PREFIX/bin).
   --codex-home PATH      Use this Codex home (default: ~/.codex).
@@ -49,6 +55,12 @@ while [ "$#" -gt 0 ]; do
       ;;
     --skip-build)
       SKIP_BUILD=1
+      ;;
+    --codex-configure)
+      CONFIGURE_CODEX=1
+      ;;
+    --clean-codex-config)
+      CLEAN_CODEX_CONFIG=1
       ;;
     --no-codex-config)
       CONFIGURE_CODEX=0
@@ -83,6 +95,7 @@ while [ "$#" -gt 0 ]; do
       ;;
     --permissions)
       MCP_PERMISSIONS="${2:?missing value for --permissions}"
+      CONFIGURE_CODEX=1
       shift
       ;;
     -h | --help)
@@ -118,14 +131,94 @@ desired_mcp_block() {
   fi
 }
 
-write_codex_config() {
-  local config_dir tmp desired section backup
+codex_mcp_server_present() {
+  local section_prefix
+  section_prefix="[mcp_servers.$CODEX_MCP_SERVER_NAME"
+
+  [ -f "$CODEX_CONFIG" ] || return 1
+
+  awk -v prefix="$section_prefix" '
+    index($0, prefix) == 1 {
+      next_char = substr($0, length(prefix) + 1, 1)
+      if (next_char == "]" || next_char == ".") {
+        found = 1
+      }
+    }
+    END { exit found ? 0 : 1 }
+  ' "$CODEX_CONFIG"
+}
+
+strip_codex_mcp_server_config() {
+  local input output section_prefix
+  input="$1"
+  output="$2"
+  section_prefix="[mcp_servers.$CODEX_MCP_SERVER_NAME"
+
+  awk -v prefix="$section_prefix" '
+    index($0, prefix) == 1 {
+      next_char = substr($0, length(prefix) + 1, 1)
+      if (next_char == "]" || next_char == ".") {
+        skip = 1
+        next
+      }
+    }
+    /^\[/ { skip = 0 }
+    !skip { lines[++n] = $0 }
+    END {
+      while (n > 0 && lines[n] == "") {
+        n--
+      }
+      for (i = 1; i <= n; i++) {
+        print lines[i]
+      }
+    }
+  ' "$input" >"$output"
+}
+
+clean_codex_config() {
+  local config_dir tmp backup
+
+  if [ "$DRY_RUN" -eq 1 ]; then
+    if codex_mcp_server_present; then
+      echo "Would remove Codex MCP server '$CODEX_MCP_SERVER_NAME' and nested tool entries from $CODEX_CONFIG"
+    else
+      echo "No Codex MCP server '$CODEX_MCP_SERVER_NAME' found in $CODEX_CONFIG"
+    fi
+    return
+  fi
+
+  if [ ! -f "$CODEX_CONFIG" ]; then
+    echo "No Codex config found at $CODEX_CONFIG; nothing to clean."
+    return
+  fi
+
   config_dir="$(dirname "$CODEX_CONFIG")"
-  section="[mcp_servers.$CODEX_MCP_SERVER_NAME]"
+  tmp="$(mktemp "$config_dir/config.toml.tmp.XXXXXX")"
+  strip_codex_mcp_server_config "$CODEX_CONFIG" "$tmp"
+
+  if cmp -s "$tmp" "$CODEX_CONFIG"; then
+    rm -f "$tmp"
+    echo "No Codex MCP server '$CODEX_MCP_SERVER_NAME' found in $CODEX_CONFIG"
+    return
+  fi
+
+  backup="$CODEX_CONFIG.bak-agent-workspace-clean-$(date +%Y%m%d%H%M%S)-$$"
+  cp -p "$CODEX_CONFIG" "$backup"
+  echo "Backed up Codex config to $backup"
+
+  mv "$tmp" "$CODEX_CONFIG"
+  chmod 600 "$CODEX_CONFIG" 2>/dev/null || true
+  CODEX_MCP_CONFIG_CHANGED=1
+  echo "Removed Codex MCP server '$CODEX_MCP_SERVER_NAME' from $CODEX_CONFIG"
+}
+
+write_codex_config() {
+  local config_dir tmp desired backup
+  config_dir="$(dirname "$CODEX_CONFIG")"
   desired="$(desired_mcp_block)"
 
   if [ "$DRY_RUN" -eq 1 ]; then
-    echo "Would register Codex MCP server in $CODEX_CONFIG:"
+    echo "Would register Codex MCP server in $CODEX_CONFIG, replacing any existing '$CODEX_MCP_SERVER_NAME' MCP/tool entries:"
     printf '%s\n' "$desired"
     return
   fi
@@ -134,19 +227,7 @@ write_codex_config() {
   tmp="$(mktemp "$config_dir/config.toml.tmp.XXXXXX")"
 
   if [ -f "$CODEX_CONFIG" ]; then
-    awk -v section="$section" '
-      $0 == section { skip = 1; next }
-      skip && /^\[/ { skip = 0 }
-      !skip { lines[++n] = $0 }
-      END {
-        while (n > 0 && lines[n] == "") {
-          n--
-        }
-        for (i = 1; i <= n; i++) {
-          print lines[i]
-        }
-      }
-    ' "$CODEX_CONFIG" >"$tmp"
+    strip_codex_mcp_server_config "$CODEX_CONFIG" "$tmp"
   else
     : >"$tmp"
   fi
@@ -170,6 +251,7 @@ write_codex_config() {
 
   mv "$tmp" "$CODEX_CONFIG"
   chmod 600 "$CODEX_CONFIG" 2>/dev/null || true
+  CODEX_MCP_CONFIG_CHANGED=1
   echo "Registered Codex MCP server '$CODEX_MCP_SERVER_NAME' in $CODEX_CONFIG"
 }
 
@@ -197,7 +279,7 @@ install_skill() {
 warn_running_mcp_processes() {
   local matches
 
-  if [ "$DRY_RUN" -eq 1 ] || [ "$CONFIGURE_CODEX" -ne 1 ]; then
+  if [ "$DRY_RUN" -eq 1 ] || { [ "$CONFIGURE_CODEX" -ne 1 ] && [ "$CLEAN_CODEX_CONFIG" -ne 1 ]; }; then
     return
   fi
 
@@ -254,6 +336,10 @@ fi
 
 if [ "$CONFIGURE_CODEX" -eq 1 ]; then
   write_codex_config
+elif [ "$CLEAN_CODEX_CONFIG" -eq 1 ]; then
+  clean_codex_config
+else
+  echo "Skipped Codex MCP config; use the Codex for Linux Agent Workspaces page for app-owned setup, or rerun with --codex-configure for a generic MCP host."
 fi
 
 if [ "$RUN_DOCTOR" -eq 1 ]; then
@@ -264,7 +350,12 @@ if [ "$RUN_DOCTOR" -eq 1 ]; then
   fi
 fi
 
-if [ "$CONFIGURE_CODEX" -eq 1 ]; then
-  warn_running_mcp_processes
-  echo "Restart Codex or reload MCP servers so new workspace tools, parameters, templates, and behavior become available."
+if [ "$DRY_RUN" -ne 1 ]; then
+  if [ "$CONFIGURE_CODEX" -eq 1 ]; then
+    warn_running_mcp_processes
+    echo "Restart Codex or reload MCP servers so new workspace tools, parameters, templates, and behavior become available."
+  elif [ "$CLEAN_CODEX_CONFIG" -eq 1 ] && [ "$CODEX_MCP_CONFIG_CHANGED" -eq 1 ]; then
+    warn_running_mcp_processes
+    echo "Restart Codex or reload MCP servers so Agent Workspace disappears from generic MCP/configuration pages."
+  fi
 fi

--- a/npm/README.md
+++ b/npm/README.md
@@ -25,7 +25,7 @@ Once installed, the server is on your PATH (the command stays unscoped):
 agent-workspace-linux
 ```
 
-It is an [MCP](https://modelcontextprotocol.io/) server that speaks JSON-RPC over stdio. Wire it into your MCP client config, e.g. for Claude Code:
+It is an [MCP](https://modelcontextprotocol.io/) server that speaks JSON-RPC over stdio. For Codex for Linux, prefer the dedicated **Agent Workspaces** feature page so command paths, permission rules, and reconnect/restart control stay out of the generic MCP settings page. If an older Codex install still shows this backend in generic MCP/configuration pages, remove the stale `agent-workspace-linux` MCP tables before reconnecting through the feature page. For other MCP clients, wire it into the client config, e.g. for Claude Code:
 
 ```json
 {

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-sh/agent-workspace-linux",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Isolated Linux desktop workspaces for AI agents — MCP server binary wrapper.",
   "license": "MIT",
   "publishConfig": {

--- a/skills/agent-workspace-linux/SKILL.md
+++ b/skills/agent-workspace-linux/SKILL.md
@@ -1,85 +1,152 @@
 ---
 name: agent-workspace-linux
-description: "Use when a task needs an isolated, hidden Linux desktop or browser the agent fully controls — GUI app QA, web/browser/shopping automation, or observing a sandboxed app — without touching the user's real mouse, keyboard, focus, or host Chrome. Triggers: 'test/QA this app', 'shop on', 'browse/automate a site', 'run a GUI app in a sandbox', 'clean desktop to test in'. Routes the agent-workspace-linux MCP tools on demand. Does NOT apply to driving the user's real/host desktop (use computer-use) or to pure code/file edits."
+description: "Use when a task needs an isolated hidden Linux desktop or workspace-owned browser: GUI app QA, web/browser/shopping automation, sandboxed app observation, or stale workspace cleanup. Routes agent-workspace-linux MCP tools on demand. Does NOT apply to host desktop/Chrome control, generic MCP setup, or pure code/file edits."
 ---
 
 # agent-workspace-linux
 
-Drive an isolated, agent-owned Linux desktop (hidden X11 display) and a workspace-owned browser through the `agent-workspace-linux` MCP server. The workspace runs apps and sends input only to its own display — never the user's real desktop, focus, or Chrome.
+Drive an isolated, agent-owned Linux desktop and workspace-owned browser through
+the `agent-workspace-linux` MCP server. The workspace runs apps, browser
+automation, screenshots, clipboard, and input inside its own hidden display,
+never the user's real desktop, focus, or host Chrome.
 
-This skill is the entry point. The MCP exposes ~86 tools; **do not load them all**. Read the phase you are in below and call only those tools. Names are the logical MCP tool names; your host namespaces them (Claude Code: `mcp__agent-workspace-linux__<name>`; Codex: same logical name). If your host defers tool schemas, load a tool's schema on demand right before calling it.
+This skill is the lightweight entry point. The MCP exposes many tools; do not
+load, list, or paste them all up front. Route by phase and ask the host to load
+only the tool schemas needed for the next action.
 
-## When to use
+## Critical Boundaries
 
-- **App / GUI QA** in a throwaway desktop: launch an app, drive it, screenshot, read logs, stop.
-- **Browser / web / shopping** tasks that must not hijack the user's live Chrome or steal focus.
-- **Observe / inspect** a sandboxed app's windows, output, or events.
-- **Cleanup** of stale or orphaned workspaces.
+### Use the dedicated Codex for Linux feature page for setup
+Codex for Linux owns Agent Workspace setup through the **Agent Workspaces** page:
+binary path, page-authored permission rules, permission file mutation,
+Reconnect/Smoke test, profile creation, workspace start/stop, and viewer launch.
+Do not send users to generic MCP settings, general configuration pages, or
+`~/.codex/config.toml` for normal Codex for Linux setup.
 
-Skip unless: the task needs to *run or drive a real GUI app or browser* in isolation. For driving the user's actual desktop, use `computer-use`. For pure code, file, or shell work, do not start a workspace.
+Skip unless: the host is Codex for Linux and the task is setup, permission
+changes, reconnect/restart, or the workspace tools are unavailable.
 
-## Permission model (read before mutating)
+### Keep tools progressive
+The bundled installer is skill-first. `./install.sh` installs this skill under
+`~/.codex/skills` by default and leaves generic Codex MCP config untouched
+unless the user explicitly chooses `--codex-configure` or `--permissions`.
+For migration only, `./install.sh --clean-codex-config` removes stale generic
+Codex MCP entries left by older installs; restart or reconnect Codex afterward.
 
-- **Default**: the MCP imposes no ceiling and defers to the host tool's boundary (Claude Code / Codex own approval). Call `mcp_permissions` once to confirm `configured=false`. After the user approves the hidden workspace once, workspace-local actions are scoped to it — do not re-prompt per action.
-- **Developer ceiling**: a dev may set `AGENT_WORKSPACE_PERMISSIONS=/path/to/permissions.json` (or launch the MCP with `--permissions PATH`). Then network mode, mount paths, and an app allowlist are a hard ceiling enforced at both the MCP front-end and the workspace daemon — you cannot broaden it. Check it with `mcp_permissions` before planning launches.
-- **Live control is best-effort**: the viewer's read_only / paused state (`mcp_control_state`) honors a user's runtime pause when readable, but it is a convenience layer, not the authoritative boundary. The permission ceiling is.
-- **Real-world actions** (checkout, purchase, account changes, sending messages) always need explicit user approval. Keep cart-drafting separate from checkout.
+Skip unless: the user asks how to install/register the backend or why the tool
+family should not be loaded at startup.
 
-Skip unless: you are about to start a workspace or launch/input — then `mcp_permissions` first.
+### Never target the host desktop
+Use this skill only for the hidden workspace. For the user's real Linux desktop,
+real Chrome profile, existing tabs, or host focus/mouse/keyboard, use the
+appropriate host-desktop or browser tool instead.
 
-## Safe workflow
+Skip unless: the requested action can run inside the isolated workspace display
+or workspace-owned browser.
 
-Always orient before mutating. Prefer the read-only planners.
+## When To Use
 
-1. **Orient** — `mcp_agent_context` for one snapshot (active/read_only/paused, viewer, handles, recovery), then `mcp_task_plan` for a safe step sequence matched to the intent (app-QA / browser / observe / cleanup). `workspace_doctor` reports runtime + host-display readiness; `workspace_list` shows existing/stale workspaces.
-2. **Start** — `workspace_start` with `ack_hidden_workspace=true` and a human `purpose`, or `workspace_open_profile` for a saved profile. A host-visible viewer opens by default unless headless.
-3. **Observe** — `workspace_observe` (status + windows + pointer + optional screenshot in one call), `workspace_screenshot`, `workspace_list_windows`.
-4. **Act** — `workspace_launch_app` / `workspace_run_app`; input via `workspace_click`, `workspace_type_text`, `workspace_key`, `workspace_paste_text`; manage windows with focus/move/resize/close tools.
-5. **Stop** — `workspace_stop` when done. Use `workspace_cleanup_stale` to reclaim orphaned runtimes.
+- GUI app QA in a throwaway desktop.
+- Browser/web/shopping automation that must not hijack host Chrome.
+- Observation of sandboxed windows, logs, events, screenshots, or artifacts.
+- Cleanup of stale or orphaned agent workspaces.
 
-## Browser tasks
+Skip unless: the user task requires running or driving a real GUI app/browser in
+isolation. For pure code, shell, or file edits, do not start a workspace.
 
-Use the **workspace-owned** browser over its loopback DevTools endpoint — never the user's host Chrome.
+## Permission Model
 
-- `workspace_open_browser` launches workspace Chrome/Chromium with an isolated `--user-data-dir` and loopback CDP.
-- `workspace_browser_targets` discovers pages; `workspace_browser_snapshot` reads page text/links; `workspace_browser_navigate` changes URL; `workspace_browser_search_results` extracts structured cards; `workspace_browser_click` interacts.
+- **Default**: no MCP ceiling is configured; the host/client owns approvals.
+  Call `mcp_permissions` once before mutating to confirm `configured=false`.
+- **Permission ceiling**: `--permissions PATH` or
+  `AGENT_WORKSPACE_PERMISSIONS` caps network, mounts, and app allowlist for the
+  life of that MCP process. It can only be broadened by changing the config and
+  restarting/reconnecting the backend from the owning setup surface.
+- **Live control**: `mcp_control_state` read-only/paused/active is a
+  best-effort runtime control, not the authoritative security boundary.
+- **Real-world actions**: checkout, purchases, account changes, and messages
+  require explicit user approval. Keep drafting separate from final action.
 
-Skip unless: the task is browser/web automation. Do not attach to the host Chrome bridge, Playwright, or Computer Use as a shortcut.
+Skip unless: you are about to start a workspace, open a profile, launch/run an
+app, send input, or act on an external account/site.
 
-## Tool map (load per phase, not all at once)
+## Phase Router
 
-| Phase | Tools |
-|-------|-------|
-| Orient (read-only) | `mcp_agent_context`, `mcp_session_brief`, `mcp_task_plan`, `mcp_permissions`, `mcp_action_catalog`, `workspace_doctor`, `workspace_list`, `workspace_status` |
+Always orient before mutating.
+
+| Phase | Load only these tools |
+| --- | --- |
+| Orient | `mcp_agent_context`, `mcp_session_brief`, `mcp_task_plan`, `mcp_permissions`, `mcp_action_catalog`, `workspace_doctor`, `workspace_list`, `workspace_status` |
 | Profiles | `profile_list`, `profile_get`, `profile_template`, `profile_put`, `profile_check` |
 | Start | `workspace_start`, `workspace_open_profile` |
-| Observe (read-only) | `workspace_observe`, `workspace_screenshot`, `workspace_list_windows`, `workspace_active_window`, `workspace_read_app_log`, `workspace_events` |
-| Act (mutating) | `workspace_launch_app`, `workspace_run_app`, `workspace_click`, `workspace_type_text`, `workspace_key`, `workspace_paste_text`, `workspace_focus_window`, `workspace_close_window` |
+| Observe | `workspace_observe`, `workspace_screenshot`, `workspace_list_windows`, `workspace_active_window`, `workspace_read_app_log`, `workspace_events` |
+| Act | `workspace_launch_app`, `workspace_run_app`, `workspace_click`, `workspace_type_text`, `workspace_key`, `workspace_paste_text`, `workspace_focus_window`, `workspace_close_window` |
 | Browser | `workspace_open_browser`, `workspace_browser_targets`, `workspace_browser_snapshot`, `workspace_browser_navigate`, `workspace_browser_search_results`, `workspace_browser_click` |
-| Control / viewer (best-effort) | `mcp_control_state`, `mcp_control_update`, `workspace_open_viewer`, `workspace_list_viewers`, `workspace_close_viewer` |
+| Viewer/control | `mcp_control_state`, `mcp_control_update`, `workspace_open_viewer`, `workspace_list_viewers`, `workspace_close_viewer` |
 | Teardown | `workspace_stop`, `workspace_kill_app`, `workspace_cleanup_stale` |
+
+Skip unless: the current phase needs one of the listed capabilities. Do not load
+schemas for later phases until the plan reaches them.
+
+## Safe Workflow
+
+1. Orient: call `mcp_agent_context` or `mcp_session_brief`, then use
+   `mcp_task_plan` for app-QA, browser, observe, or cleanup intent.
+2. Check permissions: call `mcp_permissions` before mutating.
+3. Start: use `workspace_start` with `ack_hidden_workspace=true` and a clear
+   `purpose`, or `workspace_open_profile` for a saved profile.
+4. Observe: use `workspace_observe` or focused screenshot/window/log/event
+   tools before sending input.
+5. Act: launch apps, run commands, click/type/paste/key only inside the
+   workspace.
+6. Stop: use `workspace_stop` when finished; use `workspace_cleanup_stale` for
+   orphaned runtimes.
+
+Skip unless: each step's precondition is visible in the previous tool result
+(workspace id, app id, target window, browser target, or explicit user approval).
+
+## Browser Tasks
+
+Use the workspace-owned browser over its loopback DevTools endpoint. Start with
+`workspace_open_browser`, discover pages with `workspace_browser_targets`, read
+with `workspace_browser_snapshot` or `workspace_browser_search_results`, then
+navigate or click with browser tools.
+
+Skip unless: the task is web/browser automation that can run in the isolated
+workspace. Do not attach to host Chrome, Playwright, or Computer Use as a
+shortcut.
 
 ## Do NOT
 
-- Do not load or list all workspace tools up front — pull only the current phase's tools.
-- Do not send input to or screenshot the user's real desktop; this MCP is the *isolated* workspace (use `computer-use` for the host).
-- Do not start a workspace without `ack_hidden_workspace` and a `purpose`.
-- Do not perform checkout / purchase / account / send actions without explicit user approval.
-- Do not attach to the user's host Chrome, Playwright, or Computer Use for browser work — use the workspace browser tools.
-- Do not leave workspaces running; stop and, if needed, `workspace_cleanup_stale`.
+- Do not dump all MCP tools into the agent context at startup.
+- Do not send users to generic MCP/configuration pages for Codex for Linux
+  Agent Workspace setup.
+- Do not start a workspace without `ack_hidden_workspace=true` and a `purpose`.
+- Do not send input to or screenshot the user's real desktop.
+- Do not perform purchases, checkout, account changes, or sends without explicit
+  user approval.
+- Do not leave workspaces running after the task.
 
-## Example trajectory
+## Example Trajectory
 
 Task: "QA the settings dialog of myapp."
-1. `mcp_agent_context` → not running, host display present, no ceiling.
-2. `mcp_task_plan` (app-QA) → reviewed plan: start → observe → input → evidence → stop.
-3. `workspace_start { ack_hidden_workspace: true, purpose: "QA myapp settings" }`.
-4. `workspace_launch_app { command: ["myapp"] }` → `workspace_observe` to find the window.
-5. `workspace_click` / `workspace_type_text` to open and exercise Settings; `workspace_screenshot` for evidence.
-6. `workspace_read_app_log` for errors; `workspace_stop`.
+
+1. `mcp_agent_context` and `mcp_task_plan` for app-QA.
+2. `mcp_permissions` to confirm the active boundary.
+3. `workspace_start` with `ack_hidden_workspace=true` and purpose
+   `"QA myapp settings"`.
+4. `workspace_launch_app` with the app command.
+5. `workspace_observe` to find the window.
+6. `workspace_click` / `workspace_type_text` to exercise Settings.
+7. `workspace_screenshot` and `workspace_read_app_log` for evidence.
+8. `workspace_stop`.
 
 ## Constraints
 
-- Always-loaded cost is the frontmatter only (~70 tokens). The body (~1.5–2k tokens) loads on activation; individual tool schemas load on demand.
-- This skill intentionally omits a restrictive `allowed-tools` list so it can route to the full `agent-workspace-linux` tool family on demand. The host's deferred tool-loading keeps schemas out of context until used.
-- Validate with `agnix --target all` (zero errors/warnings expected).
+- Keep activation low-noise: only use this skill for isolated GUI/browser work.
+- Keep context small: frontmatter loads by default; body loads on activation;
+  tool schemas load on demand.
+- Omit `allowed-tools` intentionally: different hosts namespace MCP tools
+  differently, and the skill routes the full family progressively.
+- Validate with `agnix --target generic|claude-code|cursor|codex|kiro`
+  when changing this file.

--- a/src/server.rs
+++ b/src/server.rs
@@ -3041,7 +3041,7 @@ impl AgentWorkspaceLinux {
 
 #[tool_handler(
     name = "agent-workspace-linux",
-    version = "0.1.0",
+    version = "0.1.1",
     instructions = "\
 Use mcp_agent_context for one low-noise snapshot with active/read_only/paused, headless/no-host-display, viewer, app_id/window_id/viewer_id/browser_target_id handles, and recovery hints. Use mcp_permissions first when the host may have spawned this MCP with a permissions ceiling, mcp_control_state to check whether live user control has put the server in active, read_only, or paused mode, mcp_action_catalog when deciding whether a tool is read-only, idempotent, destructive, host-visible/open-world, or blocked by live control, mcp_session_brief when you need a condensed session summary with suggested next actions, and mcp_task_plan when the user intent is app QA, browser/shopping, observation, or cleanup and you need a safe read-only plan before calling mutating tools. \
 If configured=true, any populated permission dimensions are an immutable spawn-time ceiling for profile, start, launch, setup, and startup actions; clients may only narrow those dimensions. If configured=true but restricted=false, the MCP has an explicit empty/open ceiling, so enforcement stays open while the configured state remains visible. If configured=false, the MCP does not impose its own ceiling; respect the host/client harness boundary and use mcp_action_catalog plus each tool's annotations and description to classify the action type before acting. \


### PR DESCRIPTION
## Summary
- make Codex MCP registration opt-in and add cleanup for stale agent-workspace MCP/tool tables
- move the bundled skill to a Codex-first progressive setup path
- bump Cargo/npm/MCP metadata to v0.1.1 for the patch release

## Validation
- bash -n install.sh
- ./install.sh --dry-run --skip-build --no-doctor --no-skill
- ./install.sh --dry-run --skip-build --no-doctor --no-skill --codex-configure
- ./install.sh --dry-run --skip-build --no-doctor --no-skill --clean-codex-config
- node --check npm/scripts/postinstall.js
- node --check npm/bin/agent-workspace-linux.js
- cargo fmt --check
- cargo build --locked
- cargo test --locked
- cargo clippy --locked -- -D warnings
- agnix --target codex skills/agent-workspace-linux/SKILL.md
- agnix --target generic skills/agent-workspace-linux/SKILL.md
- cd npm && npm pack --dry-run
