### PR TITLE
ci: ignore RUSTSEC-2026-0173 (proc-macro-error2 unmaintained)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,15 +92,17 @@ jobs:
         run: cargo install cargo-audit --locked
 
       - name: Audit dependencies
-        # The three ignored advisories are "unmaintained" warnings (not
+        # The four ignored advisories are "unmaintained" warnings (not
         # vulnerabilities) for transitive crates pulled in by the gpui git
-        # dependency (async-std, instant, paste); they are not fixable from this
-        # crate. Everything else is still denied, so a real advisory fails CI.
+        # dependency (async-std, instant, paste, proc-macro-error2); they are
+        # not fixable from this crate. Everything else is still denied, so a
+        # real advisory fails CI.
         run: |
           cargo audit --deny warnings \
             --ignore RUSTSEC-2025-0052 \
             --ignore RUSTSEC-2024-0384 \
-            --ignore RUSTSEC-2024-0436
+            --ignore RUSTSEC-2024-0436 \
+            --ignore RUSTSEC-2026-0173
 
   # Validate the shipped SKILL.md and any agent config via agnix.
   # Scoped to skills/ rather than the repo root so the linter only sees the


### PR DESCRIPTION
New unmaintained-crate advisory (2026-06-07) firing on the Supply chain job since the gpui bump landed - chain: gpui -> stacksafe -> stacksafe-macro -> proc-macro-error2. Warning-level, not a vulnerability, not fixable here. Adds it to the existing gpui-transitive ignore list. Unblocks #15.