### PR TITLE
[codex] Fail closed on unreadable daemon control state

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,10 +107,10 @@ The single most important thing to understand is **who sets the limits in each s
 |----------|-----------------------|------------------|----------------------------------|
 | **Default** (no `--permissions`) | Your **agent host** (Claude Code, Codex, …) | The MCP adds **no ceiling of its own** and defers to the host's approval flow. One explicit hidden-workspace acknowledgement scopes workspace-local actions to that environment. | Yes — the host/user owns approvals. |
 | **Developer ceiling** (`--permissions file.json` or `AGENT_WORKSPACE_PERMISSIONS` env) | The **developer / operator** who launched the MCP | Network mode, mount paths, and an app allowlist, **enforced at both the MCP front-end and the workspace daemon's IPC socket** — so even workspace-launched apps and other same-uid processes are capped. | **No** — only by restarting the MCP with new config. This is the authoritative boundary. |
-| **Live viewer control** (pause / read-only) | The **human watching**, in real time | Best-effort: honors a runtime pause when the shared control state is readable, and fails open if it isn't. | It's a convenience layer, **not** the security boundary — the ceiling above is. |
+| **Live viewer control** (pause / read-only) | The **human watching**, in real time | Honors a runtime pause when the shared control state is readable; if the daemon cannot read that state, mutating IPC fails closed while inspection and stop remain available. | It's a convenience layer, **not** the security boundary — the ceiling above is. |
 | **Workspace vs. host** | The **runtime** | Input, screenshots, windows, clipboard, and browser control target the hidden workspace **only** — never your real desktop or host Chrome. | Leakage to the host is a reportable bug. |
 
-In short: **by default the agent host owns permission**, a developer can **lock a hard, daemon-enforced ceiling** via flag or env, and the **viewer gives a human a best-effort live stop** — layered, not conflicting. See [docs/permission-model.md](docs/permission-model.md) and [SECURITY.md](SECURITY.md) for the full model and trust assumptions.
+In short: **by default the agent host owns permission**, a developer can **lock a hard, daemon-enforced ceiling** via flag or env, and the **viewer gives a human live pause/read-only/stop controls** — layered, not conflicting. See [docs/permission-model.md](docs/permission-model.md) and [SECURITY.md](SECURITY.md) for the full model and trust assumptions.
 
 ## Core concepts
 
@@ -148,7 +148,7 @@ The MCP exposes ~86 tools. To avoid dumping them all into the agent's context, i
 - Optional, daemon-enforced permission ceiling (network / mounts / app allowlist) via flag or `AGENT_WORKSPACE_PERMISSIONS`.
 - bubblewrap-backed mount and network isolation (`disabled`, `local_only`, `inherit_host`) when available.
 - Workspace-owned browser control over loopback CDP — discover targets, read pages, navigate, extract results.
-- A native floating viewer with best-effort live pause / read-only / stop.
+- A native floating viewer with live pause / read-only / stop.
 - Saveable profiles with setup and startup commands.
 - A bundled skill for low-context, on-demand tool use across MCP hosts.
 
@@ -158,7 +158,7 @@ The MCP exposes ~86 tools. To avoid dumping them all into the agent's context, i
 - **Pre-1.0.** Interfaces and tool schemas can change between versions.
 - **Single-user trust model.** The control socket is a same-uid Unix socket (mode 0600); there is no cross-user protection by design. Run as a dedicated user for multi-user isolation.
 - **Mount/network enforcement needs bubblewrap.** Without it, those policies are declared but not enforced (the runtime tells you which).
-- **Live viewer control is best-effort**, not a hard guarantee — the permission ceiling is the authoritative boundary.
+- **Live viewer control is not the hard permission boundary** — the permission ceiling is authoritative, while unreadable live-control state fails closed for mutating daemon IPC.
 
 ## Docs
 

--- a/docs/permission-model.md
+++ b/docs/permission-model.md
@@ -14,7 +14,8 @@ to the host tool's approval flow (Claude Code, Codex, and similar). In that mode
 the acknowledgement parameters and approval bundles are API shape and audit
 metadata for the host UI; a richer human-approval experience in Codex for Linux
 is the part still being built. Live viewer control (read_only/paused) is a
-best-effort convenience, not an authoritative boundary.
+runtime convenience, not an authoritative boundary; mutating daemon IPC fails
+closed if the shared control state cannot be read.
 
 See [Status and remaining work](#status-and-remaining-work) for what is done and
 what is still planned.
@@ -206,10 +207,11 @@ Rules:
   start/open-profile, direct launch/run, and profile setup/startup launches) and
   the workspace daemon IPC socket (every IPC request, including those from
   workspace-launched apps and other same-uid callers). Live control state
-  (read_only/paused) is a separate, best-effort convenience layer: the daemon
-  honors a runtime pause when it can read the shared control state and fails open
-  if it cannot, so it is not relied on as a security boundary. The standalone CLI
-  can also generate and validate ceiling files for hosts that do not have the
+  (read_only/paused) is a separate runtime convenience layer: the daemon honors
+  a runtime pause when it can read the shared control state and fails closed for
+  mutating IPC if it cannot, while read-only inspection and the safety stop stay
+  available. It is still not the authoritative security boundary. The standalone
+  CLI can also generate and validate ceiling files for hosts that do not have the
   Codex for Linux UI.
 - The CLI also accepts a leading `--permissions PATH` global option. When used,
   profile and workspace actions are checked against the same ceiling. This is

--- a/src/control.rs
+++ b/src/control.rs
@@ -105,11 +105,7 @@ pub fn ensure_control_state_initialized(
     reason: Option<String>,
 ) -> Result<()> {
     let path = control_state_path();
-    if path.exists() {
-        return Ok(());
-    }
-    set_control_mode(McpControlMode::Active, updated_by, reason)?;
-    Ok(())
+    ensure_control_state_initialized_at_path(&path, updated_by, reason)
 }
 
 pub fn set_control_mode(
@@ -150,6 +146,23 @@ fn load_existing_control_state_from_path(path: &Path) -> Result<McpControlState>
         bail!("MCP control state empty at {}", path.display());
     }
     serde_json::from_str(&content).with_context(|| format!("failed to parse {}", path.display()))
+}
+
+fn ensure_control_state_initialized_at_path(
+    path: &Path,
+    updated_by: impl Into<String>,
+    reason: Option<String>,
+) -> Result<()> {
+    if load_existing_control_state_from_path(path).is_ok() {
+        return Ok(());
+    }
+    let state = McpControlState {
+        mode: McpControlMode::Active,
+        updated_at_unix: wall_clock_seconds(),
+        updated_by: Some(updated_by.into()),
+        reason: reason.filter(|reason| !reason.trim().is_empty()),
+    };
+    save_control_state_to_path(path, &state)
 }
 
 fn save_control_state_to_path(path: &Path, state: &McpControlState) -> Result<()> {
@@ -252,6 +265,47 @@ mod tests {
         fs::write(&path, "{not json").expect("write invalid state");
         let error = load_control_state_from_path(&path).expect_err("invalid state should fail");
         assert!(error.to_string().contains("failed to parse"));
+        let _ = fs::remove_file(&path);
+    }
+
+    #[test]
+    fn initialization_repairs_corrupt_control_state() {
+        let path = temp_control_path("repair-corrupt");
+        fs::write(&path, "{not json").expect("write invalid state");
+
+        ensure_control_state_initialized_at_path(
+            &path,
+            "test",
+            Some("repair corrupt state".to_string()),
+        )
+        .expect("repair corrupt state");
+
+        let loaded = load_existing_control_state_from_path(&path).expect("load repaired state");
+        assert_eq!(loaded.mode, McpControlMode::Active);
+        assert_eq!(loaded.updated_by.as_deref(), Some("test"));
+        assert_eq!(loaded.reason.as_deref(), Some("repair corrupt state"));
+        let _ = fs::remove_file(&path);
+    }
+
+    #[test]
+    fn initialization_preserves_valid_control_state() {
+        let path = temp_control_path("preserve-valid");
+        let state = McpControlState {
+            mode: McpControlMode::ReadOnly,
+            updated_at_unix: 42,
+            updated_by: Some("existing".to_string()),
+            reason: Some("user paused".to_string()),
+        };
+        save_control_state_to_path(&path, &state).expect("save state");
+
+        ensure_control_state_initialized_at_path(&path, "test", None)
+            .expect("preserve valid state");
+
+        let loaded = load_existing_control_state_from_path(&path).expect("load state");
+        assert_eq!(loaded.mode, McpControlMode::ReadOnly);
+        assert_eq!(loaded.updated_at_unix, 42);
+        assert_eq!(loaded.updated_by.as_deref(), Some("existing"));
+        assert_eq!(loaded.reason.as_deref(), Some("user paused"));
         let _ = fs::remove_file(&path);
     }
 

--- a/src/control.rs
+++ b/src/control.rs
@@ -94,6 +94,24 @@ pub fn control_status() -> Result<McpControlStatus> {
     Ok(McpControlStatus { path, state })
 }
 
+pub fn strict_control_status() -> Result<McpControlStatus> {
+    let path = control_state_path();
+    let state = load_existing_control_state_from_path(&path)?;
+    Ok(McpControlStatus { path, state })
+}
+
+pub fn ensure_control_state_initialized(
+    updated_by: impl Into<String>,
+    reason: Option<String>,
+) -> Result<()> {
+    let path = control_state_path();
+    if path.exists() {
+        return Ok(());
+    }
+    set_control_mode(McpControlMode::Active, updated_by, reason)?;
+    Ok(())
+}
+
 pub fn set_control_mode(
     mode: McpControlMode,
     updated_by: impl Into<String>,
@@ -118,6 +136,18 @@ fn load_control_state_from_path(path: &Path) -> Result<McpControlState> {
         fs::read_to_string(path).with_context(|| format!("failed to read {}", path.display()))?;
     if content.trim().is_empty() {
         return Ok(McpControlState::default());
+    }
+    serde_json::from_str(&content).with_context(|| format!("failed to parse {}", path.display()))
+}
+
+fn load_existing_control_state_from_path(path: &Path) -> Result<McpControlState> {
+    if !path.exists() {
+        bail!("MCP control state missing at {}", path.display());
+    }
+    let content =
+        fs::read_to_string(path).with_context(|| format!("failed to read {}", path.display()))?;
+    if content.trim().is_empty() {
+        bail!("MCP control state empty at {}", path.display());
     }
     serde_json::from_str(&content).with_context(|| format!("failed to parse {}", path.display()))
 }
@@ -180,6 +210,25 @@ mod tests {
     }
 
     #[test]
+    fn strict_missing_control_state_fails_closed() {
+        let path = temp_control_path("strict-missing");
+        let _ = fs::remove_file(&path);
+        let error =
+            load_existing_control_state_from_path(&path).expect_err("missing state should fail");
+        assert!(error.to_string().contains("MCP control state missing"));
+    }
+
+    #[test]
+    fn strict_empty_control_state_fails_closed() {
+        let path = temp_control_path("strict-empty");
+        fs::write(&path, "\n").expect("write empty state");
+        let error =
+            load_existing_control_state_from_path(&path).expect_err("empty state should fail");
+        assert!(error.to_string().contains("MCP control state empty"));
+        let _ = fs::remove_file(&path);
+    }
+
+    #[test]
     fn control_state_round_trips() {
         let path = temp_control_path("round-trip");
         let _ = fs::remove_file(&path);
@@ -204,6 +253,31 @@ mod tests {
         let error = load_control_state_from_path(&path).expect_err("invalid state should fail");
         assert!(error.to_string().contains("failed to parse"));
         let _ = fs::remove_file(&path);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn strict_unreadable_control_state_fails_closed() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let path = temp_control_path("strict-unreadable");
+        let _ = fs::remove_file(&path);
+        fs::write(&path, r#"{"mode":"active"}"#).expect("write state");
+        let original_permissions = fs::metadata(&path).expect("state metadata").permissions();
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o000))
+            .expect("remove state permissions");
+
+        let result = load_existing_control_state_from_path(&path);
+
+        fs::set_permissions(&path, original_permissions).expect("restore state permissions");
+        let _ = fs::remove_file(&path);
+
+        if result.is_ok() {
+            eprintln!("skipping unreadable-file assertion for privileged test user");
+            return;
+        }
+        let error = result.expect_err("unreadable state should fail");
+        assert!(error.to_string().contains("failed to read"));
     }
 
     #[test]

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -3231,6 +3231,10 @@ pub fn run_daemon(mut options: DaemonOptions) -> Result<()> {
         Some(path) => load_mcp_permission_state(path)?,
         None => McpPermissionState::default(),
     };
+    control::ensure_control_state_initialized(
+        "workspace_daemon",
+        Some("initialize missing live control state for workspace daemon".to_string()),
+    )?;
 
     let mut x_server = spawn_xvfb(&options)?;
     wait_for_display(&options.display, &options.xauthority_path)?;
@@ -4189,42 +4193,63 @@ fn handle_stream(stream: UnixStream, state: &mut DaemonState) -> Result<bool> {
         serde_json::from_str(line.trim()).context("failed to parse workspace IPC request")?;
     refresh_apps(state)?;
 
-    // Apply live control (active / read_only / paused) inside the daemon as a
-    // best-effort convenience layer, NOT the authoritative boundary. The control
-    // mode is file-backed (control::control_status reads mcp-control.json under
-    // the shared runtime dir), so this daemon observes mode changes made by the
-    // viewer or MCP front-end and can honor a user's runtime pause. It is gated
-    // before the request match so no mutating handler runs while paused, and
-    // read-only inspection plus the safety stop stay allowed even when paused.
-    // Crucially, this is independent of the permission ceiling: the ceiling is
+    // Apply live control (active / read_only / paused) inside the daemon. The
+    // control mode is file-backed (mcp-control.json under the shared runtime
+    // dir), so this daemon observes mode changes made by the viewer or MCP
+    // front-end and can honor a user's runtime pause. It is gated before the
+    // request match so no mutating handler runs while paused, and read-only
+    // inspection plus the safety stop stay allowed even when paused.
+    //
+    // This remains independent of the permission ceiling: the ceiling is
     // re-checked authoritatively in spawn_app regardless of what happens here.
-    // If the control state cannot be read we fail OPEN (allow the request),
-    // because best-effort live control must never block legitimate work or
-    // become a dependency the security model relies on.
-    let control_mode = match control::control_status() {
-        Ok(status) => Some(status.state.mode),
+    // For mutating IPC, unreadable live-control state fails closed so viewer-
+    // forwarded input cannot bypass read_only/paused intent by corrupting,
+    // deleting, or making the shared control file unreadable.
+    let (control_gate_state, control_read_error) = match control::strict_control_status() {
+        Ok(status) => (LiveControlGateState::Readable(status.state.mode), None),
         Err(error) => {
-            eprintln!("best-effort live control state unreadable; allowing request: {error:#}");
-            None
+            eprintln!(
+                "live control state unreadable; mutating IPC requests will fail closed: {error:#}"
+            );
+            (LiveControlGateState::Unreadable, Some(error.to_string()))
         }
     };
-    if let Some(mode) = control_gate_block_reason(&request, control_mode) {
-        record_event(
-            state,
-            "control_blocked",
-            serde_json::json!({
-                "mode": mode.as_str(),
-                "request": ipc_request_kind(&request),
-            }),
-        )?;
-        let response = response_with_status(
-            false,
-            format!(
-                "workspace is {}; this mutating action is disabled until live control returns to active",
-                mode.label()
-            ),
-            &state.status,
-        );
+    if let Some(reason) = control_gate_block_reason(&request, control_gate_state) {
+        let response = match reason {
+            LiveControlBlockReason::Mode(mode) => {
+                record_event(
+                    state,
+                    "control_blocked",
+                    serde_json::json!({
+                        "mode": mode.as_str(),
+                        "request": ipc_request_kind(&request),
+                    }),
+                )?;
+                response_with_status(
+                    false,
+                    format!(
+                        "workspace is {}; this mutating action is disabled until live control returns to active",
+                        mode.label()
+                    ),
+                    &state.status,
+                )
+            }
+            LiveControlBlockReason::Unreadable => {
+                record_event(
+                    state,
+                    "control_unreadable_blocked",
+                    serde_json::json!({
+                        "request": ipc_request_kind(&request),
+                        "error": control_read_error.as_deref().unwrap_or("unknown"),
+                    }),
+                )?;
+                response_with_status(
+                    false,
+                    "live control state is unreadable; mutating actions are disabled until the control state can be read",
+                    &state.status,
+                )
+            }
+        };
         return finish_ipc_response(stream, response, false);
     }
 
@@ -6519,22 +6544,36 @@ fn finish_ipc_response(
     Ok(should_stop)
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LiveControlGateState {
+    Readable(McpControlMode),
+    Unreadable,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LiveControlBlockReason {
+    Mode(McpControlMode),
+    Unreadable,
+}
+
 /// Pure live-control gate decision: given an incoming request and the current
-/// control mode, return `Some(mode)` when the request must be blocked (it
-/// mutates and the mode does not allow agent mutation), or `None` when it is
-/// allowed. Kept separate from `handle_stream` so it can be unit-tested without
-/// touching the file-backed control state or process-global environment.
-///
-/// `mode` is `None` when the live control state is unknown/unreadable. In that
-/// case this returns `None` (allow): live control is a best-effort convenience,
-/// so it fails OPEN and never blocks work. The authoritative permission ceiling
-/// is enforced separately in `spawn_app` and does not depend on this gate.
+/// control state, return `Some(reason)` when the request must be blocked, or
+/// `None` when it is allowed. Kept separate from `handle_stream` so it can be
+/// unit-tested without touching the file-backed control state or process-global
+/// environment.
 fn control_gate_block_reason(
     request: &IpcRequest,
-    mode: Option<McpControlMode>,
-) -> Option<McpControlMode> {
-    match mode {
-        Some(mode) if request_mutates(request) && !mode.allows_agent_mutation() => Some(mode),
+    state: LiveControlGateState,
+) -> Option<LiveControlBlockReason> {
+    match state {
+        LiveControlGateState::Readable(mode)
+            if request_mutates(request) && !mode.allows_agent_mutation() =>
+        {
+            Some(LiveControlBlockReason::Mode(mode))
+        }
+        LiveControlGateState::Unreadable if request_mutates(request) => {
+            Some(LiveControlBlockReason::Unreadable)
+        }
         _ => None,
     }
 }
@@ -10244,48 +10283,101 @@ mod tests {
 
         // Paused blocks mutating ops.
         assert_eq!(
-            control_gate_block_reason(&mutating, Some(McpControlMode::Paused)),
-            Some(McpControlMode::Paused)
+            control_gate_block_reason(
+                &mutating,
+                LiveControlGateState::Readable(McpControlMode::Paused)
+            ),
+            Some(LiveControlBlockReason::Mode(McpControlMode::Paused))
         );
         assert_eq!(
-            control_gate_block_reason(&type_text, Some(McpControlMode::Paused)),
-            Some(McpControlMode::Paused)
+            control_gate_block_reason(
+                &type_text,
+                LiveControlGateState::Readable(McpControlMode::Paused)
+            ),
+            Some(LiveControlBlockReason::Mode(McpControlMode::Paused))
         );
         // Read-only inspection stays allowed even when paused.
         assert_eq!(
-            control_gate_block_reason(&read_only, Some(McpControlMode::Paused)),
+            control_gate_block_reason(
+                &read_only,
+                LiveControlGateState::Readable(McpControlMode::Paused)
+            ),
             None
         );
         // Safety stop stays allowed even when paused.
         assert_eq!(
-            control_gate_block_reason(&safety_stop, Some(McpControlMode::Paused)),
+            control_gate_block_reason(
+                &safety_stop,
+                LiveControlGateState::Readable(McpControlMode::Paused)
+            ),
             None
         );
         // read_only mode also blocks mutating ops and allows inspection.
         assert_eq!(
-            control_gate_block_reason(&mutating, Some(McpControlMode::ReadOnly)),
-            Some(McpControlMode::ReadOnly)
+            control_gate_block_reason(
+                &mutating,
+                LiveControlGateState::Readable(McpControlMode::ReadOnly)
+            ),
+            Some(LiveControlBlockReason::Mode(McpControlMode::ReadOnly))
         );
         assert_eq!(
-            control_gate_block_reason(&read_only, Some(McpControlMode::ReadOnly)),
+            control_gate_block_reason(
+                &read_only,
+                LiveControlGateState::Readable(McpControlMode::ReadOnly)
+            ),
             None
         );
         // Active permits everything.
         assert_eq!(
-            control_gate_block_reason(&mutating, Some(McpControlMode::Active)),
+            control_gate_block_reason(
+                &mutating,
+                LiveControlGateState::Readable(McpControlMode::Active)
+            ),
             None
         );
         assert_eq!(
-            control_gate_block_reason(&safety_stop, Some(McpControlMode::Active)),
+            control_gate_block_reason(
+                &safety_stop,
+                LiveControlGateState::Readable(McpControlMode::Active)
+            ),
             None
         );
 
-        // Best-effort fail-open: when the live control state is unreadable
-        // (mode is None), even mutating ops are allowed. Live control is a
-        // convenience layer, not the authoritative boundary; the permission
-        // ceiling is enforced independently in spawn_app.
-        assert_eq!(control_gate_block_reason(&mutating, None), None);
-        assert_eq!(control_gate_block_reason(&type_text, None), None);
+        // Unreadable live-control state fails closed for mutating IPC while
+        // preserving read-only inspection and the safety stop.
+        let click = IpcRequest::Click {
+            x: 1,
+            y: 2,
+            button: 1,
+            count: 1,
+        };
+        let key = IpcRequest::Key {
+            key: "Escape".to_string(),
+        };
+        let paste = IpcRequest::PasteText {
+            text: "hello".to_string(),
+            key: "ctrl+v".to_string(),
+        };
+        assert_eq!(
+            control_gate_block_reason(&click, LiveControlGateState::Unreadable),
+            Some(LiveControlBlockReason::Unreadable)
+        );
+        assert_eq!(
+            control_gate_block_reason(&key, LiveControlGateState::Unreadable),
+            Some(LiveControlBlockReason::Unreadable)
+        );
+        assert_eq!(
+            control_gate_block_reason(&paste, LiveControlGateState::Unreadable),
+            Some(LiveControlBlockReason::Unreadable)
+        );
+        assert_eq!(
+            control_gate_block_reason(&read_only, LiveControlGateState::Unreadable),
+            None
+        );
+        assert_eq!(
+            control_gate_block_reason(&safety_stop, LiveControlGateState::Unreadable),
+            None
+        );
 
         // Dry-run previews are treated as read-only.
         let kill_dry_run = IpcRequest::KillApp {
@@ -10297,12 +10389,18 @@ mod tests {
             dry_run: false,
         };
         assert_eq!(
-            control_gate_block_reason(&kill_dry_run, Some(McpControlMode::Paused)),
+            control_gate_block_reason(
+                &kill_dry_run,
+                LiveControlGateState::Readable(McpControlMode::Paused)
+            ),
             None
         );
         assert_eq!(
-            control_gate_block_reason(&kill_real, Some(McpControlMode::Paused)),
-            Some(McpControlMode::Paused)
+            control_gate_block_reason(
+                &kill_real,
+                LiveControlGateState::Readable(McpControlMode::Paused)
+            ),
+            Some(LiveControlBlockReason::Mode(McpControlMode::Paused))
         );
     }
 


### PR DESCRIPTION
## Summary

Fixes #21 by making the workspace daemon fail closed for mutating IPC when the shared live-control state cannot be read. Read-only inspection and the safety stop still work, and fresh daemon startup initializes a missing control file to the normal active state so new workspaces remain usable.

## Root Cause

The daemon converted `control_status()` failures into `None`, and the pure gate treated `None` as allowed. Viewer-forwarded input reaches the daemon IPC path directly, so corrupting, deleting, or making `mcp-control.json` unreadable allowed mutating requests to bypass read_only/paused intent.

## Changes

- Added strict live-control reads for daemon IPC enforcement.
- Added a distinct `control_unreadable_blocked` event for blocked mutating requests.
- Kept status/inspection and `Stop` available when the control state is unreadable.
- Initialized a missing control state at daemon startup to preserve fresh-workspace behavior.
- Updated README and permission-model docs to remove the stale fail-open contract.

## Validation

- `cargo fmt --check`
- `cargo test --bin agent-workspace-linux control`
- `cargo test --bin agent-workspace-linux daemon_control_gate_blocks_mutation_but_allows_readonly_and_stop`
- `cargo test --bin agent-workspace-linux`
- `cargo build --bin agent-workspace-linux`
- Isolated CLI smoke with a temp `XDG_RUNTIME_DIR`: start workspace, corrupt `mcp-control.json`, verify `workspace status` succeeds, verify `workspace key` returns `ok:false` with the unreadable-control message, verify `workspace events` contains `control_unreadable_blocked` for request `key`, then stop workspace.