### PR TITLE
[codex] Cap workspace clipboard paste payloads

### DIFF
--- a/docs/gpui-viewer-direction.md
+++ b/docs/gpui-viewer-direction.md
@@ -40,7 +40,9 @@ footer mode in the user's XDG config directory.
   manual read-write capability. Forwarding is still disabled when the window
   appears; the human must click the in-viewer `Input` control twice to arm it.
   All forwarded mouse, keyboard, scroll, and paste events go through
-  workspace-owned IPC for the selected workspace, never the host desktop.
+  workspace-owned IPC for the selected workspace, never the host desktop. Paste
+  forwarding reads text from the host clipboard and sends at most 64 KiB into
+  the workspace.
 - MCP-opened viewers pass `--exit-when-workspace-gone`, so monitors opened for a
   task disappear when their selected workspace runtime is removed.
 - Direct `agent-workspace-linux viewer` launches remain persistent, so they can

--- a/src/server.rs
+++ b/src/server.rs
@@ -2679,7 +2679,7 @@ impl AgentWorkspaceLinux {
 
     #[tool(
         name = "workspace_set_clipboard",
-        description = "Set the clipboard selection inside an isolated agent workspace. Event logs store only size metadata, not the raw clipboard text.",
+        description = "Set the clipboard selection inside an isolated agent workspace. Text is capped at 64 KiB. Event logs store only size metadata, not the raw clipboard text.",
         annotations(
             read_only_hint = false,
             destructive_hint = false,
@@ -2724,7 +2724,7 @@ impl AgentWorkspaceLinux {
 
     #[tool(
         name = "workspace_paste_text",
-        description = "Set the isolated workspace clipboard to text, then send a paste key chord to the focused app. Defaults to ctrl+v. Response includes active_window when focus can be resolved after the action. Event logs store only size metadata, not the raw text.",
+        description = "Set the isolated workspace clipboard to text, then send a paste key chord to the focused app. Text is capped at 64 KiB. Defaults to ctrl+v. Response includes active_window when focus can be resolved after the action. Event logs store only size metadata, not the raw text.",
         annotations(
             read_only_hint = false,
             destructive_hint = false,
@@ -2749,7 +2749,7 @@ impl AgentWorkspaceLinux {
 
     #[tool(
         name = "workspace_paste_window",
-        description = "Set the isolated workspace clipboard to text, focus a visible window by X11 id/title/class/pid/app filter, then send a paste key chord. Prefer app_id from workspace_launch_app when controlling a launched app because GUI titles can change. Defaults to ctrl+v. Response includes the target window and active_window when focus can be resolved after the action. Event logs store only size metadata, not the raw text.",
+        description = "Set the isolated workspace clipboard to text, focus a visible window by X11 id/title/class/pid/app filter, then send a paste key chord. Text is capped at 64 KiB. Prefer app_id from workspace_launch_app when controlling a launched app because GUI titles can change. Defaults to ctrl+v. Response includes the target window and active_window when focus can be resolved after the action. Event logs store only size metadata, not the raw text.",
         annotations(
             read_only_hint = false,
             destructive_hint = false,

--- a/src/viewer.rs
+++ b/src/viewer.rs
@@ -761,6 +761,13 @@ fn push_bounded_input_forwarding_request(
     dropped
 }
 
+fn host_clipboard_too_large_message(byte_len: usize) -> String {
+    format!(
+        "Host clipboard text is {byte_len} bytes; maximum workspace paste is {} bytes",
+        workspace::MAX_CLIPBOARD_TEXT_BYTES
+    )
+}
+
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 enum DragKind {
     Move,
@@ -1421,13 +1428,13 @@ impl AgentWorkspaceViewer {
             self.input_forwarding_enabled = true;
             self.input_forwarding_arm_expires_at_unix = None;
             self.message =
-                "Manual input forwarding enabled; clicks, scroll, keys, and paste target only the isolated workspace"
+                "Manual input forwarding enabled; clicks, scroll, keys, and host clipboard paste target only the isolated workspace"
                     .to_string();
             self.error = None;
         } else {
             self.input_forwarding_arm_expires_at_unix = Some(now + INPUT_FORWARD_CONFIRM_SECONDS);
             self.message = format!(
-                "Click Input again within {INPUT_FORWARD_CONFIRM_SECONDS}s to forward clicks, scroll, and keyboard into {}",
+                "Click Input again within {INPUT_FORWARD_CONFIRM_SECONDS}s to forward clicks, scroll, keyboard, and host clipboard paste into {}",
                 self.target_id
             );
             self.error = None;
@@ -1699,7 +1706,17 @@ impl AgentWorkspaceViewer {
 
         let request = if is_paste_keystroke(&event.keystroke) {
             match cx.read_from_clipboard().and_then(|item| item.text()) {
-                Some(text) if !text.is_empty() => InputForwardingRequest::PasteText { text },
+                Some(text) if !text.is_empty() => {
+                    let byte_len = text.len();
+                    if byte_len > workspace::MAX_CLIPBOARD_TEXT_BYTES {
+                        self.message = host_clipboard_too_large_message(byte_len);
+                        self.error = None;
+                        cx.stop_propagation();
+                        cx.notify();
+                        return;
+                    }
+                    InputForwardingRequest::PasteText { text }
+                }
                 _ => {
                     self.message = "Host clipboard has no text to paste".to_string();
                     self.error = None;
@@ -2789,7 +2806,7 @@ impl Render for AgentWorkspaceViewer {
             )
         } else if let Some(seconds_left) = input_forward_confirm_seconds_left {
             format!(
-                "Manual input is opt-in: click Input again within {seconds_left}s to forward clicks, scroll, and keyboard into the isolated workspace"
+                "Manual input is opt-in: click Input again within {seconds_left}s to forward clicks, scroll, keyboard, and host clipboard paste into the isolated workspace"
             )
         } else if let Some(reason) = input_forwarding_wait_reason {
             format!("Manual input forwarding is enabled but {reason}")
@@ -3030,7 +3047,7 @@ impl Render for AgentWorkspaceViewer {
                                 "viewer-input-on",
                                 "Input",
                                 Some(tooltip_text(
-                                    "Manual input forwarding is ON: clicks, drag release, scroll, keyboard, and paste target the isolated workspace. Hover motion is not forwarded.",
+                                    "Manual input forwarding is ON: clicks, drag release, scroll, keyboard, and host clipboard paste target the isolated workspace. Hover motion is not forwarded.",
                                 )),
                                 on_input,
                             )
@@ -3039,7 +3056,7 @@ impl Render for AgentWorkspaceViewer {
                                 "viewer-input-confirm",
                                 "Input?",
                                 Some(tooltip_text(
-                                    "Confirm opt-in: forward viewer clicks, scroll, keyboard, and paste into the isolated workspace only",
+                                    "Confirm opt-in: forward viewer clicks, scroll, keyboard, and host clipboard text into the isolated workspace only",
                                 )),
                                 on_input,
                             )
@@ -3048,7 +3065,7 @@ impl Render for AgentWorkspaceViewer {
                                 "viewer-input",
                                 "Input",
                                 Some(tooltip_text(
-                                    "Opt in to manual read-write control through this viewer (requires a second click)",
+                                    "Opt in to manual read-write control through this viewer, including host clipboard paste (requires a second click)",
                                 )),
                                 on_input,
                             )
@@ -6199,6 +6216,17 @@ mod tests {
             Some((7, target, InputForwardingRequest::Click { x: 999, y: 1, button: 1 }))
                 if target == "qa"
         ));
+    }
+
+    #[test]
+    fn host_clipboard_size_message_names_workspace_paste_boundary() {
+        let byte_len = workspace::MAX_CLIPBOARD_TEXT_BYTES + 1;
+        let message = host_clipboard_too_large_message(byte_len);
+
+        assert!(message.contains("Host clipboard text"));
+        assert!(message.contains(&byte_len.to_string()));
+        assert!(message.contains(&workspace::MAX_CLIPBOARD_TEXT_BYTES.to_string()));
+        assert!(message.contains("workspace paste"));
     }
 
     #[test]

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -54,6 +54,7 @@ const ESRCH: i32 = 3;
 const PRIVATE_RUNTIME_DIR_MODE: u32 = 0o700;
 const PRIVATE_SOCKET_MODE: u32 = 0o600;
 const MAX_UNIX_SOCKET_PATH_BYTES: usize = 107;
+pub(crate) const MAX_CLIPBOARD_TEXT_BYTES: usize = 64 * 1024;
 const APPLIED_POLICY_FILE: &str = "applied_policy.json";
 const EVENT_LOG_FILE: &str = "events.jsonl";
 const WORKSPACE_MANIFEST_FILE: &str = "workspace.json";
@@ -9632,6 +9633,12 @@ fn validate_clipboard_text(text: &str) -> Result<()> {
     if text.is_empty() {
         bail!("clipboard text cannot be empty");
     }
+    let byte_len = text.len();
+    if byte_len > MAX_CLIPBOARD_TEXT_BYTES {
+        bail!(
+            "clipboard text is {byte_len} bytes; maximum is {MAX_CLIPBOARD_TEXT_BYTES} bytes. Paste a smaller selection or transfer large content through a mounted file"
+        );
+    }
     if text.contains('\0') {
         bail!("clipboard text cannot contain NUL bytes");
     }
@@ -9905,6 +9912,20 @@ mod tests {
         assert_eq!(detail["source"], "workspace_screenshot_window");
         assert_eq!(detail["target"], "window");
         assert_eq!(detail["window_id"], "4194307");
+    }
+
+    #[test]
+    fn clipboard_text_rejects_oversized_payloads() {
+        let at_limit = "x".repeat(MAX_CLIPBOARD_TEXT_BYTES);
+        validate_clipboard_text(&at_limit).expect("limit-sized clipboard text should pass");
+
+        let too_large = "x".repeat(MAX_CLIPBOARD_TEXT_BYTES + 1);
+        let error =
+            validate_clipboard_text(&too_large).expect_err("oversized clipboard text should fail");
+        let message = error.to_string();
+        assert!(message.contains(&(MAX_CLIPBOARD_TEXT_BYTES + 1).to_string()));
+        assert!(message.contains(&MAX_CLIPBOARD_TEXT_BYTES.to_string()));
+        assert!(message.contains("mounted file"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes #22 by adding a 64 KiB cap for text sent into the isolated workspace clipboard/paste paths and by making viewer input-forwarding copy explicit about host clipboard text crossing into the workspace.

## Root Cause

`validate_clipboard_text` only rejected empty text and NUL bytes, so `workspace_set_clipboard`, `workspace_paste_text`, `workspace_paste_window`, and viewer-forwarded paste could carry an unbounded single text payload into the workspace. The viewer opt-in text also described generic paste without making the host clipboard source clear.

## Changes

- Added `MAX_CLIPBOARD_TEXT_BYTES` at 64 KiB and enforce it in shared clipboard validation.
- Return an actionable oversized-payload error suggesting smaller selections or mounted files for large content.
- Preflight oversized host clipboard text in the viewer before queuing a forwarded paste.
- Updated viewer messages/tooltips/footer wording to explicitly name host clipboard paste.
- Updated MCP tool descriptions and GPUI viewer direction docs to mention the cap and host-to-workspace paste direction.

## Validation

- `cargo fmt --check`
- `cargo test --bin agent-workspace-linux clipboard_text_rejects_oversized_payloads`
- `cargo test --bin agent-workspace-linux host_clipboard_size_message_names_workspace_paste_boundary`
- `cargo test --bin agent-workspace-linux input_forwarding_queue_keeps_recent_requests_with_fixed_cap`
- `cargo test --bin agent-workspace-linux`
- `cargo build --bin agent-workspace-linux`
- Isolated CLI smoke with a temp `XDG_RUNTIME_DIR`: start workspace, send a 65,537-byte payload to `workspace paste` and `workspace clipboard-set`, verify both exit with `clipboard text is 65537 bytes; maximum is 65536 bytes...`, then stop workspace.