### PR TITLE
fix: deliver synthetic clicks to XInput2 apps and show the pointer in captures

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ schemars = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "1.51", features = ["macros", "rt"] }
-x11rb = "0.13.2"
+x11rb = { version = "0.13.2", features = ["xtest"] }
 
 [profile.release]
 codegen-units = 1

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,7 @@ mod profile;
 mod server;
 mod viewer;
 mod workspace;
+mod xtest_input;
 
 use anyhow::{bail, Context, Result};
 use policy::{AppliedWorkspacePolicy, MountMode, ProfileMount};
@@ -26,6 +27,11 @@ use workspace::{DaemonOptions, EnvVar, LaunchSpec, WorkspaceStartOptions};
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<()> {
     let mut args = std::env::args().skip(1).collect::<Vec<_>>();
+    // Internal helper: synthetic XTEST pointer input (motion+button) used by the
+    // workspace daemon so synthetic clicks reach XInput2 apps (winit/egui, …).
+    if args.first().map(String::as_str) == Some("__xtest") {
+        return xtest_input::run(&args[1..]);
+    }
     let permissions = parse_global_options(&mut args)?;
     match args.first().map(String::as_str) {
         Some("doctor") => {

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -8317,7 +8317,33 @@ fn capture_workspace_screenshot(
             .with_context(|| format!("failed to create {}", parent.display()))?;
     }
 
-    if command_path_check("import").ok {
+    // Prefer ffmpeg's x11grab: it is the only readily-available capture that can
+    // composite the pointer sprite (`-draw_mouse 1`) into the frame. Xvfb keeps
+    // the cursor in a separate XFIXES plane, so `import`/`scrot` (and therefore
+    // the live viewer that streams these frames) render no cursor at all.
+    if command_path_check("ffmpeg").ok {
+        let video_size = format!("{}x{}", status.width, status.height);
+        let output = workspace_command(status, "ffmpeg")
+            .args([
+                "-y",
+                "-loglevel",
+                "error",
+                "-f",
+                "x11grab",
+                "-draw_mouse",
+                "1",
+                "-video_size",
+                &video_size,
+                "-i",
+                &status.display,
+                "-frames:v",
+                "1",
+            ])
+            .arg(&path)
+            .output()
+            .context("failed to run ffmpeg for workspace screenshot")?;
+        output_text(output, "ffmpeg x11grab")?;
+    } else if command_path_check("import").ok {
         let output = workspace_command(status, "import")
             .args(["-window", "root"])
             .arg(&path)
@@ -8560,26 +8586,43 @@ fn show_workspace_window(status: &WorkspaceStatus, window_id: &str) -> Result<Wo
     window_info(status, &window_id)
 }
 
+/// Run the embedded `__xtest` synthetic-input helper as a child process so it
+/// inherits the workspace DISPLAY/XAUTHORITY. Motion is injected via
+/// `XTestFakeMotionEvent` (a real device event XInput2 apps like winit observe),
+/// unlike `xdotool mousemove` which warps the pointer without a motion event and
+/// leaves egui/winit clicking at a stale position.
+fn run_xtest_input(status: &WorkspaceStatus, args: &[String]) -> Result<()> {
+    let exe = std::env::current_exe().context("resolve current executable for xtest input")?;
+    let exe = exe
+        .to_str()
+        .context("current executable path is not valid UTF-8")?;
+    let output = workspace_command(status, exe)
+        .arg("__xtest")
+        .args(args)
+        .output()
+        .context("failed to run __xtest input helper")?;
+    output_text(output, "xtest input")?;
+    Ok(())
+}
+
 fn click_workspace(status: &WorkspaceStatus, x: i32, y: i32, button: u8, count: u8) -> Result<()> {
     validate_workspace_coordinates(status, x, y, "click")?;
     validate_click_options(button, count)?;
-    let output = workspace_command(status, "xdotool")
-        .args(["mousemove", "--sync", &x.to_string(), &y.to_string()])
-        .args(["click", "--repeat", &count.to_string(), &button.to_string()])
-        .output()
-        .context("failed to run xdotool click")?;
-    output_text(output, "xdotool click")?;
-    Ok(())
+    run_xtest_input(
+        status,
+        &[
+            "click".to_string(),
+            x.to_string(),
+            y.to_string(),
+            button.to_string(),
+            count.to_string(),
+        ],
+    )
 }
 
 fn move_workspace_pointer(status: &WorkspaceStatus, x: i32, y: i32) -> Result<()> {
     validate_workspace_coordinates(status, x, y, "pointer")?;
-    let output = workspace_command(status, "xdotool")
-        .args(["mousemove", "--sync", &x.to_string(), &y.to_string()])
-        .output()
-        .context("failed to run xdotool mousemove")?;
-    output_text(output, "xdotool mousemove")?;
-    Ok(())
+    run_xtest_input(status, &["move".to_string(), x.to_string(), y.to_string()])
 }
 
 fn drag_workspace(
@@ -8593,20 +8636,17 @@ fn drag_workspace(
     validate_workspace_coordinates(status, from_x, from_y, "drag start")?;
     validate_workspace_coordinates(status, to_x, to_y, "drag end")?;
     validate_click_options(button, DEFAULT_CLICK_COUNT)?;
-    let output = workspace_command(status, "xdotool")
-        .args([
-            "mousemove",
-            "--sync",
-            &from_x.to_string(),
-            &from_y.to_string(),
-        ])
-        .args(["mousedown", &button.to_string()])
-        .args(["mousemove", "--sync", &to_x.to_string(), &to_y.to_string()])
-        .args(["mouseup", &button.to_string()])
-        .output()
-        .context("failed to run xdotool drag")?;
-    output_text(output, "xdotool drag")?;
-    Ok(())
+    run_xtest_input(
+        status,
+        &[
+            "drag".to_string(),
+            from_x.to_string(),
+            from_y.to_string(),
+            to_x.to_string(),
+            to_y.to_string(),
+            button.to_string(),
+        ],
+    )
 }
 
 fn scroll_workspace(
@@ -8618,15 +8658,16 @@ fn scroll_workspace(
 ) -> Result<()> {
     validate_workspace_coordinates(status, x, y, "scroll")?;
     validate_scroll_options(direction, amount)?;
-    let button = direction.x11_button().to_string();
-    let amount = amount.to_string();
-    let output = workspace_command(status, "xdotool")
-        .args(["mousemove", "--sync", &x.to_string(), &y.to_string()])
-        .args(["click", "--repeat", &amount, &button])
-        .output()
-        .context("failed to run xdotool scroll")?;
-    output_text(output, "xdotool scroll")?;
-    Ok(())
+    run_xtest_input(
+        status,
+        &[
+            "scroll".to_string(),
+            x.to_string(),
+            y.to_string(),
+            direction.x11_button().to_string(),
+            amount.to_string(),
+        ],
+    )
 }
 
 fn key_workspace(status: &WorkspaceStatus, key: String) -> Result<()> {

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -1077,7 +1077,10 @@ pub fn doctor_report() -> DoctorReport {
         xprop: command_path_check("xprop"),
         window_manager: first_available_command(&["openbox", "i3", "fluxbox"]),
         xdotool: command_path_check("xdotool"),
-        screenshot: first_available_command(&["import", "scrot"]),
+        // Mirror the runtime capture order in capture_workspace_screenshot:
+        // ffmpeg (cursor-capable) is preferred, then import/scrot. An
+        // ffmpeg-only host can take screenshots, so it must read as ready here.
+        screenshot: first_available_command(&["ffmpeg", "import", "scrot"]),
         clipboard: first_available_command(&["xclip", "xsel"]),
         policy: policy_runtime_capabilities(),
     };
@@ -1116,7 +1119,10 @@ pub fn doctor_report() -> DoctorReport {
         );
     }
     if !runtime.screenshot.ok {
-        blockers.push("Install ImageMagick import or scrot for workspace screenshots.".to_string());
+        blockers.push(
+            "Install ffmpeg (cursor capture), ImageMagick import, or scrot for workspace screenshots."
+                .to_string(),
+        );
     }
 
     let mut viewer_blockers = Vec::new();

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -11,7 +11,9 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::{
     collections::{BTreeMap, BTreeSet},
-    env, fs,
+    env,
+    ffi::OsStr,
+    fs,
     io::{self, BufRead, BufReader, Read, Write},
     os::unix::{
         ffi::OsStrExt,
@@ -8321,28 +8323,44 @@ fn capture_workspace_screenshot(
     // composite the pointer sprite (`-draw_mouse 1`) into the frame. Xvfb keeps
     // the cursor in a separate XFIXES plane, so `import`/`scrot` (and therefore
     // the live viewer that streams these frames) render no cursor at all.
+    //
+    // ffmpeg may be installed yet unusable here (built without x11grab, minimal
+    // container, …), so treat any failure as non-fatal and fall back to the
+    // cursor-less capture utilities rather than aborting the screenshot.
+    let mut captured = false;
     if command_path_check("ffmpeg").ok {
         let video_size = format!("{}x{}", status.width, status.height);
-        let output = workspace_command(status, "ffmpeg")
-            .args([
-                "-y",
-                "-loglevel",
-                "error",
-                "-f",
-                "x11grab",
-                "-draw_mouse",
-                "1",
-                "-video_size",
-                &video_size,
-                "-i",
-                &status.display,
-                "-frames:v",
-                "1",
-            ])
-            .arg(&path)
-            .output()
-            .context("failed to run ffmpeg for workspace screenshot")?;
-        output_text(output, "ffmpeg x11grab")?;
+        let run_ffmpeg = || -> Result<()> {
+            let output = workspace_command(status, "ffmpeg")
+                .args([
+                    "-y",
+                    "-loglevel",
+                    "error",
+                    "-f",
+                    "x11grab",
+                    "-draw_mouse",
+                    "1",
+                    "-video_size",
+                    &video_size,
+                    "-i",
+                    &status.display,
+                    "-frames:v",
+                    "1",
+                ])
+                .arg(&path)
+                .output()
+                .context("failed to run ffmpeg for workspace screenshot")?;
+            output_text(output, "ffmpeg x11grab")?;
+            Ok(())
+        };
+        match run_ffmpeg() {
+            Ok(()) => captured = true,
+            Err(err) => eprintln!("ffmpeg screenshot failed, falling back: {err:#}"),
+        }
+    }
+
+    if captured {
+        // Captured with the cursor composited in.
     } else if command_path_check("import").ok {
         let output = workspace_command(status, "import")
             .args(["-window", "root"])
@@ -8357,7 +8375,7 @@ fn capture_workspace_screenshot(
             .context("failed to run scrot for workspace screenshot")?;
         output_text(output, "scrot")?;
     } else {
-        bail!("missing screenshot command: install ImageMagick import or scrot");
+        bail!("missing screenshot command: install ffmpeg (cursor capture), ImageMagick import, or scrot");
     }
 
     workspace_screenshot_result(
@@ -8592,11 +8610,12 @@ fn show_workspace_window(status: &WorkspaceStatus, window_id: &str) -> Result<Wo
 /// unlike `xdotool mousemove` which warps the pointer without a motion event and
 /// leaves egui/winit clicking at a stale position.
 fn run_xtest_input(status: &WorkspaceStatus, args: &[String]) -> Result<()> {
-    let exe = std::env::current_exe().context("resolve current executable for xtest input")?;
-    let exe = exe
-        .to_str()
-        .context("current executable path is not valid UTF-8")?;
-    let output = workspace_command(status, exe)
+    // Reuse daemon_executable_path() so an updated/replaced binary (whose
+    // /proc/self/exe reads back as "… (deleted)") still resolves to the stable
+    // on-disk path; pass the PathBuf straight through to avoid rejecting
+    // non-UTF8 executable paths.
+    let exe = daemon_executable_path().context("resolve current executable for xtest input")?;
+    let output = workspace_command(status, &exe)
         .arg("__xtest")
         .args(args)
         .output()
@@ -9104,7 +9123,7 @@ fn app_exit_event_detail(app: &WorkspaceApp) -> serde_json::Value {
     })
 }
 
-fn workspace_command(status: &WorkspaceStatus, program: &str) -> Command {
+fn workspace_command(status: &WorkspaceStatus, program: impl AsRef<OsStr>) -> Command {
     let mut command = Command::new(program);
     configure_x11_workspace_process_environment(&mut command, status);
     command.stdin(Stdio::null());

--- a/src/xtest_input.rs
+++ b/src/xtest_input.rs
@@ -1,0 +1,110 @@
+//! Synthetic pointer input via the XTEST extension.
+//!
+//! `xdotool mousemove` positions the pointer with `XWarpPointer`, a server-side
+//! warp that XInput2 clients (winit/egui, GTK4, …) do not observe as a
+//! `CursorMoved`/motion event. Since winit's button event carries no position,
+//! egui then resolves the click against a stale pointer location and the click
+//! lands on the wrong widget (or nowhere).
+//!
+//! `XTestFakeMotionEvent` instead injects a real device motion that XInput2
+//! reports, so the target app updates its pointer position before the button.
+//! This helper performs the whole motion+button sequence over XTEST.
+//!
+//! It is spawned as an internal `__xtest` subcommand by the workspace daemon so
+//! it inherits the per-workspace `DISPLAY`/`XAUTHORITY` (no global env mutation
+//! in the long-lived server process, which must keep its own host `DISPLAY`).
+
+use anyhow::{bail, Context, Result};
+use x11rb::connection::Connection;
+use x11rb::protocol::xproto::ConnectionExt as _;
+use x11rb::protocol::xtest::ConnectionExt as _;
+
+const MOTION_NOTIFY: u8 = 6;
+const BUTTON_PRESS: u8 = 4;
+const BUTTON_RELEASE: u8 = 5;
+
+/// Entry point for `agent-workspace-linux __xtest <op> ...`.
+///
+/// Ops (all coordinates are root-relative on the workspace display):
+///   move  X Y
+///   click X Y BUTTON [COUNT]
+///   scroll X Y BUTTON [COUNT]
+///   drag  X1 Y1 X2 Y2 BUTTON
+pub fn run(args: &[String]) -> Result<()> {
+    let (conn, screen_num) = x11rb::connect(None).context("XTEST: connect to workspace display")?;
+    let root = conn.setup().roots[screen_num].root;
+
+    let motion = |x: i16, y: i16| -> Result<()> {
+        conn.xtest_fake_input(MOTION_NOTIFY, 0, x11rb::CURRENT_TIME, root, x, y, 0)?;
+        conn.flush()?;
+        Ok(())
+    };
+    let button = |b: u8, press: bool| -> Result<()> {
+        let kind = if press { BUTTON_PRESS } else { BUTTON_RELEASE };
+        conn.xtest_fake_input(kind, b, x11rb::CURRENT_TIME, root, 0, 0, 0)?;
+        conn.flush()?;
+        Ok(())
+    };
+    // Let the app process the motion (emit CursorMoved) before the button.
+    let settle = || std::thread::sleep(std::time::Duration::from_millis(25));
+
+    let parse = |s: &str, what: &str| -> Result<i16> {
+        s.parse::<i16>()
+            .with_context(|| format!("XTEST: invalid {what}: {s:?}"))
+    };
+
+    match args.first().map(String::as_str) {
+        Some("move") if args.len() >= 3 => {
+            motion(parse(&args[1], "x")?, parse(&args[2], "y")?)?;
+        }
+        Some("click") if args.len() >= 4 => {
+            let (x, y) = (parse(&args[1], "x")?, parse(&args[2], "y")?);
+            let b = parse(&args[3], "button")? as u8;
+            let count = args
+                .get(4)
+                .and_then(|s| s.parse::<u8>().ok())
+                .unwrap_or(1)
+                .max(1);
+            motion(x, y)?;
+            settle();
+            for _ in 0..count {
+                button(b, true)?;
+                std::thread::sleep(std::time::Duration::from_millis(15));
+                button(b, false)?;
+                std::thread::sleep(std::time::Duration::from_millis(15));
+            }
+        }
+        Some("scroll") if args.len() >= 4 => {
+            let (x, y) = (parse(&args[1], "x")?, parse(&args[2], "y")?);
+            let b = parse(&args[3], "button")? as u8;
+            let count = args
+                .get(4)
+                .and_then(|s| s.parse::<u8>().ok())
+                .unwrap_or(1)
+                .max(1);
+            motion(x, y)?;
+            settle();
+            for _ in 0..count {
+                button(b, true)?;
+                button(b, false)?;
+            }
+        }
+        Some("drag") if args.len() >= 6 => {
+            let (x1, y1) = (parse(&args[1], "x1")?, parse(&args[2], "y1")?);
+            let (x2, y2) = (parse(&args[3], "x2")?, parse(&args[4], "y2")?);
+            let b = parse(&args[5], "button")? as u8;
+            motion(x1, y1)?;
+            settle();
+            button(b, true)?;
+            settle();
+            motion(x2, y2)?;
+            settle();
+            button(b, false)?;
+        }
+        other => bail!("XTEST: unknown op {:?}", other),
+    }
+
+    // Round-trip so every faked event is processed before we exit.
+    conn.get_input_focus()?.reply()?;
+    Ok(())
+}

--- a/src/xtest_input.rs
+++ b/src/xtest_input.rs
@@ -48,9 +48,22 @@ pub fn run(args: &[String]) -> Result<()> {
     // Let the app process the motion (emit CursorMoved) before the button.
     let settle = || std::thread::sleep(std::time::Duration::from_millis(25));
 
+    // Callers validate/serialize coordinates as i32/u32 (no upper bound on
+    // --width/--height), but the XTEST wire protocol carries root_x/root_y as
+    // i16. Parse the wider type first, then narrow with an explicit range check
+    // so an out-of-range coordinate (display larger than 32767 px) yields a
+    // clear bounds error instead of a confusing "invalid" parse failure.
     let parse = |s: &str, what: &str| -> Result<i16> {
-        s.parse::<i16>()
-            .with_context(|| format!("XTEST: invalid {what}: {s:?}"))
+        let v: i32 = s
+            .parse()
+            .with_context(|| format!("XTEST: invalid {what}: {s:?}"))?;
+        i16::try_from(v).with_context(|| {
+            format!(
+                "XTEST: {what} {v} out of range for XTEST (must be {}..={})",
+                i16::MIN,
+                i16::MAX
+            )
+        })
     };
     // Buttons are X11 button IDs (1..=255); parse as u8 so out-of-range or
     // negative input fails loudly instead of silently wrapping (e.g. 300 -> 44).

--- a/src/xtest_input.rs
+++ b/src/xtest_input.rs
@@ -52,6 +52,12 @@ pub fn run(args: &[String]) -> Result<()> {
         s.parse::<i16>()
             .with_context(|| format!("XTEST: invalid {what}: {s:?}"))
     };
+    // Buttons are X11 button IDs (1..=255); parse as u8 so out-of-range or
+    // negative input fails loudly instead of silently wrapping (e.g. 300 -> 44).
+    let parse_button = |s: &str| -> Result<u8> {
+        s.parse::<u8>()
+            .with_context(|| format!("XTEST: invalid button: {s:?}"))
+    };
 
     match args.first().map(String::as_str) {
         Some("move") if args.len() >= 3 => {
@@ -59,7 +65,7 @@ pub fn run(args: &[String]) -> Result<()> {
         }
         Some("click") if args.len() >= 4 => {
             let (x, y) = (parse(&args[1], "x")?, parse(&args[2], "y")?);
-            let b = parse(&args[3], "button")? as u8;
+            let b = parse_button(&args[3])?;
             let count = args
                 .get(4)
                 .and_then(|s| s.parse::<u8>().ok())
@@ -76,7 +82,7 @@ pub fn run(args: &[String]) -> Result<()> {
         }
         Some("scroll") if args.len() >= 4 => {
             let (x, y) = (parse(&args[1], "x")?, parse(&args[2], "y")?);
-            let b = parse(&args[3], "button")? as u8;
+            let b = parse_button(&args[3])?;
             let count = args
                 .get(4)
                 .and_then(|s| s.parse::<u8>().ok())
@@ -92,7 +98,7 @@ pub fn run(args: &[String]) -> Result<()> {
         Some("drag") if args.len() >= 6 => {
             let (x1, y1) = (parse(&args[1], "x1")?, parse(&args[2], "y1")?);
             let (x2, y2) = (parse(&args[3], "x2")?, parse(&args[4], "y2")?);
-            let b = parse(&args[5], "button")? as u8;
+            let b = parse_button(&args[5])?;
             motion(x1, y1)?;
             settle();
             button(b, true)?;


### PR DESCRIPTION
## Problem

Driving the isolated workspace for native GUI apps (winit/egui, e.g. eframe) was broken in two ways, which also hurt the live viewer experience:

### 1. Synthetic clicks did nothing in winit/egui apps
`xdotool mousemove` positions the pointer with **`XWarpPointer`**, a server-side warp that XInput2 clients do not observe as a motion event. winit's `MouseInput` carries **no position** ([rust-windowing/winit#883](https://github.com/rust-windowing/winit/issues/883)), so egui resolves the click against its last `CursorMoved` and the button lands on a stale position — i.e. nowhere useful. Keyboard worked because key events carry their own data, which is what made this confusing to diagnose.

### 2. The pointer was invisible in screenshots and the live viewer
Xvfb keeps the cursor in a separate **XFIXES** plane, so `import`/`scrot` (and therefore the viewer that streams those frames) render no cursor at all — you can't see where the agent is about to click.

## Fix

1. Route `click`/`move`/`scroll`/`drag` through **`XTestFakeMotionEvent`** (x11rb `xtest`), which injects a real device motion that XInput2 reports. The motion is performed by a small internal `__xtest` subcommand spawned with the per-workspace `DISPLAY`/`XAUTHORITY`, so the long-lived server process keeps its own host `DISPLAY` (no global env mutation).
2. Capture the root with **`ffmpeg -f x11grab -draw_mouse 1`**, falling back to `import`/`scrot` when ffmpeg is absent.

## Validation

Tested end-to-end against an `eframe`/glow app in the workspace:
- Before: `workspace_click` on buttons had no effect; the viewer showed no cursor.
- After: clicks navigate the GUI correctly (combo boxes open, buttons fire), and both `workspace_screenshot` and the live viewer show the pointer.

## Notes
- Adds the `xtest` feature to the existing `x11rb` dependency (no new crates).
- `ffmpeg` becomes the preferred screenshot backend when present; `import`/`scrot` remain as fallbacks, so no new hard dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)