### PR TITLE
fix: align window clicks with screenshots (reparent offset) + release 0.2.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,17 +95,23 @@ jobs:
         run: cargo install cargo-audit --locked
 
       - name: Audit dependencies
-        # The four ignored advisories are "unmaintained" warnings (not
-        # vulnerabilities) for transitive crates pulled in by the gpui git
-        # dependency (async-std, instant, paste, proc-macro-error2); they are
-        # not fixable from this crate. Everything else is still denied, so a
-        # real advisory fails CI.
+        # The ignored advisories are "unmaintained"/"unsound" warnings (not
+        # exploitable vulnerabilities) for transitive crates pulled in by the
+        # gpui git dependency — not fixable from this crate until gpui upstream
+        # bumps them:
+        #   RUSTSEC-2025-0052 async-std        unmaintained
+        #   RUSTSEC-2024-0384 instant          unmaintained
+        #   RUSTSEC-2024-0436 paste            unmaintained
+        #   RUSTSEC-2026-0173 proc-macro-error2 unmaintained
+        #   RUSTSEC-2026-0186 memmap2          unsound (via gpui→fontdb/cosmic-text/xkbcommon)
+        # Everything else is still denied, so a real advisory fails CI.
         run: |
           cargo audit --deny warnings \
             --ignore RUSTSEC-2025-0052 \
             --ignore RUSTSEC-2024-0384 \
             --ignore RUSTSEC-2024-0436 \
-            --ignore RUSTSEC-2026-0173
+            --ignore RUSTSEC-2026-0173 \
+            --ignore RUSTSEC-2026-0186
 
   # Validate the shipped SKILL.md and any agent config via agnix.
   # Scoped to skills/ rather than the repo root so the linter only sees the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,7 +120,7 @@ dependencies = [
 
 [[package]]
 name = "agent-workspace-linux"
-version = "0.1.6"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "gpui",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-workspace-linux"
-version = "0.1.6"
+version = "0.2.0"
 edition = "2021"
 license = "MIT"
 description = "Isolated Linux desktop workspaces for AI agents."

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ It builds from source straight from git — no crates.io needed. Install the sys
 # latest from main
 cargo install --git https://github.com/agent-sh/agent-workspace-linux
 # or pin a tagged release
-cargo install --git https://github.com/agent-sh/agent-workspace-linux --tag v0.1.6
+cargo install --git https://github.com/agent-sh/agent-workspace-linux --tag v0.2.0
 ```
 
 That puts `agent-workspace-linux` on your `PATH`. Unlike `install.sh`, it installs only the binary — register it with your MCP host manually (below), and copy `skills/agent-workspace-linux/` into your skills directory if you want the bundled skill.

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-sh/agent-workspace-linux",
-  "version": "0.1.6",
+  "version": "0.2.0",
   "description": "Isolated Linux desktop workspaces for AI agents — MCP server binary wrapper.",
   "license": "MIT",
   "publishConfig": {

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -8347,7 +8347,10 @@ fn absolute_window_origin(status: &WorkspaceStatus, id: &str) -> Option<(i32, i3
     if !output.status.success() {
         return None;
     }
-    let text = String::from_utf8(output.stdout).ok()?;
+    // Lossy: xwininfo echoes the window title, which can contain invalid UTF-8.
+    // The geometry lines we parse are pure ASCII, so a mangled title byte must
+    // not throw away the whole (valid) origin read.
+    let text = String::from_utf8_lossy(&output.stdout);
     parse_absolute_window_origin(&text)
 }
 

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -8223,6 +8223,17 @@ fn window_info_with_visibility(
         .output()
         .with_context(|| format!("failed to read window geometry for {id}"))?;
     let geometry_text = output_text(geometry_output, "xdotool getwindowgeometry")?;
+    let mut geometry = parse_window_geometry(&geometry_text)?;
+
+    // Prefer xwininfo's true absolute origin over xdotool's (which double-counts
+    // the reparent/title-bar offset under a reparenting WM). This keeps click
+    // coordinates aligned with window-screenshot pixels — see
+    // absolute_window_origin. Width/height/screen stay from xdotool; only the
+    // origin is corrected, and only when xwininfo resolves it.
+    if let Some((abs_x, abs_y)) = absolute_window_origin(status, id) {
+        geometry.x = abs_x;
+        geometry.y = abs_y;
+    }
 
     Ok(WorkspaceWindow {
         id: id.to_string(),
@@ -8232,7 +8243,7 @@ fn window_info_with_visibility(
         pid,
         app_id: pid.and_then(|pid| workspace_app_id_for_pid(status, pid)),
         visible,
-        geometry: parse_window_geometry(&geometry_text)?,
+        geometry,
     })
 }
 
@@ -8312,6 +8323,51 @@ fn parse_window_geometry(text: &str) -> Result<WindowGeometry> {
         height: height.context("window geometry missing HEIGHT")?,
         screen,
     })
+}
+
+/// The window's TRUE root-absolute upper-left, from `xwininfo`'s
+/// "Absolute upper-left X/Y".
+///
+/// Why this exists: under a reparenting WM, `xdotool getwindowgeometry` reports
+/// an origin that double-counts the frame offset (client-absolute PLUS the
+/// client's offset within its frame — e.g. a 22px title bar counted twice), so
+/// its X/Y land ~titlebar-height below the real client origin. Meanwhile
+/// `import -window <id>` captures the CLIENT drawable, whose top-left is the true
+/// absolute origin. Keying clicks off xdotool's value while screenshots use the
+/// client origin makes a coordinate read off a window screenshot miss by the
+/// title-bar height. xwininfo's "Absolute upper-left" is the same origin import
+/// captures from, so using it aligns click coordinates with screenshot pixels:
+/// a point read at (x,y) in `workspace_screenshot_window` is exactly the
+/// `click_window` (x,y) that lands there.
+fn absolute_window_origin(status: &WorkspaceStatus, id: &str) -> Option<(i32, i32)> {
+    let output = workspace_command(status, "xwininfo")
+        .args(["-id", id])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let text = String::from_utf8(output.stdout).ok()?;
+    parse_absolute_window_origin(&text)
+}
+
+/// Parse `xwininfo`'s "Absolute upper-left X/Y" lines into a root-absolute
+/// origin. Split from the spawn so it can be unit-tested on captured output.
+fn parse_absolute_window_origin(text: &str) -> Option<(i32, i32)> {
+    let mut x = None;
+    let mut y = None;
+    for line in text.lines() {
+        let line = line.trim();
+        if let Some(rest) = line.strip_prefix("Absolute upper-left X:") {
+            x = rest.trim().parse::<i32>().ok();
+        } else if let Some(rest) = line.strip_prefix("Absolute upper-left Y:") {
+            y = rest.trim().parse::<i32>().ok();
+        }
+    }
+    match (x, y) {
+        (Some(x), Some(y)) => Some((x, y)),
+        _ => None,
+    }
 }
 
 fn capture_workspace_screenshot(
@@ -9992,6 +10048,32 @@ mod tests {
         assert!(message.contains(&(MAX_CLIPBOARD_TEXT_BYTES + 1).to_string()));
         assert!(message.contains(&MAX_CLIPBOARD_TEXT_BYTES.to_string()));
         assert!(message.contains("mounted file"));
+    }
+
+    #[test]
+    fn parses_absolute_window_origin_from_xwininfo() {
+        // Real xwininfo output for a reparented window: the absolute upper-left
+        // is the true client origin (what `import -window` captures from), which
+        // differs from xdotool's double-counted geometry by the title-bar height.
+        let sample = "\
+xwininfo: Window id: 0x400005 \"Eigen\"
+
+  Absolute upper-left X:  111
+  Absolute upper-left Y:  142
+  Relative upper-left X:  1
+  Relative upper-left Y:  22
+  Width: 1180
+  Height: 760
+";
+        assert_eq!(parse_absolute_window_origin(sample), Some((111, 142)));
+    }
+
+    #[test]
+    fn absolute_window_origin_none_when_fields_absent() {
+        assert_eq!(parse_absolute_window_origin("no geometry here"), None);
+        // Negative coordinates (partially off-screen window) parse fine.
+        let sample = "  Absolute upper-left X:  -5\n  Absolute upper-left Y:  -10\n";
+        assert_eq!(parse_absolute_window_origin(sample), Some((-5, -10)));
     }
 
     #[test]


### PR DESCRIPTION
## Problem
`workspace_click_window` missed small controls in native/webview apps (toolbar buttons, list-row actions) even though hover/motion landed on them. The click coordinate read off a `workspace_screenshot_window` image landed ~title-bar-height (≈22px) too low.

## Root cause
Under a reparenting WM, `xdotool getwindowgeometry --shell` reports an origin that **double-counts** the frame offset — client-absolute PLUS the client's offset within its frame (e.g. 142 + 22px title bar = 164). Meanwhile `import -window <id>` / `scrot -u` capture the **client** drawable, whose top-left is the true root-absolute origin (142). So `click_window` keyed coordinates off the inflated origin while `screenshot_window` pixels start at the real client origin → a point read off a window screenshot and clicked back missed by the title-bar height.

## Fix
After parsing xdotool geometry, override X/Y with `xwininfo`'s "Absolute upper-left" (the same origin `import` captures from). Width/height/screen are unchanged; the correction is skipped (falls back to xdotool) when xwininfo can't resolve, so non-reparenting setups and hosts without xwininfo are unaffected.

Now a coordinate read at `(x,y)` in `workspace_screenshot_window` is exactly the `click_window` `(x,y)` that lands there.

## Verification
- New unit tests: `parse_absolute_window_origin` (incl. negative/off-screen origins + missing-field fallback). Full suite 169/169 green.
- Live: window geometry now reports `x:111,y:142` (was `112,164`); clicking at the exact pixel a window screenshot shows opened a webkit2gtk/Wails app's button — no manual correction.

## Release
Bumps 0.1.6 → **0.2.0** (Cargo.toml/Cargo.lock/npm/package.json + README pinned tag). Tag `v0.2.0` triggers `release.yml`.