### PR TITLE
fix(browser): return post-action target metadata; add open-browser CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,34 @@ agent-workspace-linux workspace observe --screenshot --output /tmp/ws.png
 agent-workspace-linux workspace stop
 ```
 
+### Browser automation
+
+Browser commands need a workspace-owned Chrome with loopback DevTools. `open-browser`
+launches one with the right flags:
+
+```bash
+# Launch workspace-owned Chrome (use --dry-run to inspect the argv first)
+agent-workspace-linux workspace open-browser --dry-run
+agent-workspace-linux workspace open-browser "http://127.0.0.1:8111"
+
+# Drive it — URL is positional
+agent-workspace-linux workspace browser-navigate "http://127.0.0.1:8111/page" --wait-ms 1500
+agent-workspace-linux workspace browser-snapshot --max-text-chars 2000
+```
+
+`browser-navigate` and `browser-click` re-read the page after acting, so `target.url` /
+`target.title` describe the page you landed on rather than the one you left. If that
+refresh fails the response carries a warning instead of silently reporting stale metadata.
+
+**Attaching your own CDP client.** DevTools binds to an *ephemeral* loopback port, and
+Chrome rejects WebSocket upgrades whose `Origin` header is not allow-listed — matching on
+the port too, so no static `--remote-allow-origins` value can match (`*` would, but it
+disables that CSRF protection). Instead, omit the `Origin` header:
+
+```python
+ws = websocket.create_connection(ws_debugger_url, suppress_origin=True)
+```
+
 Through an MCP host you don't run these by hand — the agent calls the matching tools. Start it via the [bundled skill](#the-skill-progressive-tool-loading) so the agent loads only the tools it needs.
 
 ## Who controls the boundaries

--- a/skills/agent-workspace-linux/SKILL.md
+++ b/skills/agent-workspace-linux/SKILL.md
@@ -112,6 +112,21 @@ Use the workspace-owned browser over its loopback DevTools endpoint. Start with
 with `workspace_browser_snapshot` or `workspace_browser_search_results`, then
 navigate or click with browser tools.
 
+Browser tools require a Chrome launched with `--user-data-dir` and loopback
+DevTools. Always get it from `workspace_open_browser` (MCP) or
+`workspace open-browser` (CLI) rather than hand-rolling a `workspace_launch_app`
+argv.
+
+If you attach your own CDP/WebSocket client to that endpoint, omit the `Origin`
+header (e.g. `websocket-client`'s `suppress_origin=True`). The DevTools port is
+ephemeral, so Chrome's origin allow-list cannot be pre-seeded and an `Origin`-
+bearing handshake is rejected with `403 Forbidden`.
+
+After `workspace_browser_navigate` or `workspace_browser_click`, read
+`page.url` / `page.title` for post-action state. `target.*` is refreshed to match,
+but if the refresh fails the response carries a warning saying it may be stale —
+check `warnings` before trusting `target` for verification.
+
 Skip unless: the task is web/browser automation that can run in the isolated
 workspace. Do not attach to host Chrome, Playwright, or Computer Use as a
 shortcut.

--- a/src/browser.rs
+++ b/src/browser.rs
@@ -1019,12 +1019,23 @@ pub(crate) fn workspace_browser_navigate_from_status(
     let timeout = cdp_timeout(timeout_ms);
     let navigation = navigate_target(&selected.target, &url, timeout)?;
     std::thread::sleep(Duration::from_millis(wait_ms.unwrap_or(750).min(30_000)));
-    // The target metadata was captured before navigating, so its title/url still
-    // describe the previous page. Refresh it so `target` and `page` agree.
+    let page = if snapshot {
+        Some(read_page_snapshot(
+            &selected.target,
+            max_text_chars.unwrap_or(12_000).min(200_000),
+            timeout,
+        )?)
+    } else {
+        None
+    };
+    // Target metadata was captured before navigating, so its title/url still
+    // describe the previous page. Refresh so `target` and `page` agree. When a
+    // snapshot was taken it already read document.title/location.href, so reuse
+    // it instead of paying for a second CDP round-trip.
     let mut navigated_target = selected.target.clone();
     let mut warnings = selected.targets.warnings.clone();
     warnings.extend(selected.warnings.clone());
-    match refresh_target_document(&selected.target, timeout) {
+    match refresh_target_document(&selected.target, timeout, page.as_ref()) {
         Ok((title, current_url)) => {
             navigated_target.title = title;
             navigated_target.url = current_url;
@@ -1035,15 +1046,6 @@ pub(crate) fn workspace_browser_navigate_from_status(
             ));
         }
     }
-    let page = if snapshot {
-        Some(read_page_snapshot(
-            &selected.target,
-            max_text_chars.unwrap_or(12_000).min(200_000),
-            timeout,
-        )?)
-    } else {
-        None
-    };
     let response = WorkspaceBrowserNavigate {
         ok: true,
         message: "workspace browser navigated through workspace-owned Chrome DevTools".to_string(),
@@ -1149,12 +1151,22 @@ pub(crate) fn workspace_browser_click_from_status(
         timeout,
     )?;
     std::thread::sleep(Duration::from_millis(wait_ms.unwrap_or(250).min(30_000)));
+    let page = if snapshot {
+        Some(read_page_snapshot(
+            &selected.target,
+            max_text_chars.unwrap_or(12_000).min(200_000),
+            timeout,
+        )?)
+    } else {
+        None
+    };
     // A click can navigate (links, SPA routing), so the pre-click target
-    // metadata may now describe the previous page. Refresh it.
+    // metadata may now describe the previous page. Refresh it, reusing the
+    // snapshot's document read when one was taken.
     let mut clicked_target = selected.target.clone();
     let mut warnings = selected.targets.warnings.clone();
     warnings.extend(selected.warnings.clone());
-    match refresh_target_document(&selected.target, timeout) {
+    match refresh_target_document(&selected.target, timeout, page.as_ref()) {
         Ok((title, current_url)) => {
             clicked_target.title = title;
             clicked_target.url = current_url;
@@ -1165,15 +1177,6 @@ pub(crate) fn workspace_browser_click_from_status(
             ));
         }
     }
-    let page = if snapshot {
-        Some(read_page_snapshot(
-            &selected.target,
-            max_text_chars.unwrap_or(12_000).min(200_000),
-            timeout,
-        )?)
-    } else {
-        None
-    };
     Ok(WorkspaceBrowserClick {
         ok: true,
         message: "workspace browser clicked through workspace-owned Chrome DevTools".to_string(),
@@ -1470,11 +1473,25 @@ fn cdp_timeout(timeout_ms: Option<u64>) -> Duration {
 /// Re-read `title`/`url` for a target after an action that changes the page.
 ///
 /// `/json/list` metadata is captured when the target is *selected*, which is
-/// before navigation happens. Returning that stale copy makes
+/// before the action runs. Returning that stale copy makes
 /// `target.url`/`target.title` describe the previous page while `page.*`
 /// describes the new one — callers that assert on `target` silently validate
-/// the wrong document. Cheap `Runtime.evaluate`, independent of `snapshot`.
-fn refresh_target_document(target: &BrowserTarget, timeout: Duration) -> Result<(String, String)> {
+/// the wrong document.
+///
+/// When a page snapshot was already taken it read `document.title` /
+/// `location.href` from the same live document, so reuse it rather than paying
+/// for a second CDP round-trip. Only fall back to an explicit
+/// `Runtime.evaluate` when no snapshot is available (`snapshot: false`).
+fn refresh_target_document(
+    target: &BrowserTarget,
+    timeout: Duration,
+    page: Option<&BrowserPageSnapshot>,
+) -> Result<(String, String)> {
+    if let Some(page) = page {
+        if !page.url.is_empty() {
+            return Ok((page.title.clone(), page.url.clone()));
+        }
+    }
     let value = cdp_request(
         target,
         "Runtime.evaluate",
@@ -2962,6 +2979,43 @@ mod tests {
         assert_eq!(detail["raw_result_text_omitted"], true);
         assert!(detail.get("results").is_none());
         assert!(detail.get("text_excerpt").is_none());
+    }
+
+    #[test]
+    fn refresh_target_document_reuses_snapshot_instead_of_a_second_round_trip() {
+        // A target with no webSocketDebuggerUrl cannot do CDP at all, so if this
+        // returns Ok the value must have come from the snapshot — proving the
+        // reuse path avoids a redundant Runtime.evaluate when snapshot=true.
+        let target = BrowserTarget {
+            id: "page-1".to_string(),
+            target_type: "page".to_string(),
+            title: "Stale Title".to_string(),
+            url: "http://127.0.0.1:8111/lesson/1".to_string(),
+            web_socket_debugger_url: None,
+        };
+        let page = BrowserPageSnapshot {
+            title: "Day 42 • ML Research".to_string(),
+            url: "http://127.0.0.1:8111/lesson/42".to_string(),
+            text: String::new(),
+            text_chars: 0,
+            text_truncated: false,
+            headings: Vec::new(),
+            links: Vec::new(),
+        };
+        let (title, url) =
+            refresh_target_document(&target, Duration::from_millis(500), Some(&page))
+                .expect("snapshot reuse must not require CDP");
+        assert_eq!(title, "Day 42 • ML Research");
+        assert_eq!(url, "http://127.0.0.1:8111/lesson/42");
+
+        // With no snapshot there is nothing to reuse, so it must attempt CDP and
+        // fail on the missing debugger URL rather than silently returning stale data.
+        let error = refresh_target_document(&target, Duration::from_millis(500), None)
+            .expect_err("without a snapshot it must attempt a real CDP read");
+        assert!(
+            error.to_string().contains("webSocketDebuggerUrl"),
+            "unexpected error: {error}"
+        );
     }
 
     #[test]

--- a/src/browser.rs
+++ b/src/browser.rs
@@ -1019,6 +1019,22 @@ pub(crate) fn workspace_browser_navigate_from_status(
     let timeout = cdp_timeout(timeout_ms);
     let navigation = navigate_target(&selected.target, &url, timeout)?;
     std::thread::sleep(Duration::from_millis(wait_ms.unwrap_or(750).min(30_000)));
+    // The target metadata was captured before navigating, so its title/url still
+    // describe the previous page. Refresh it so `target` and `page` agree.
+    let mut navigated_target = selected.target.clone();
+    let mut warnings = selected.targets.warnings.clone();
+    warnings.extend(selected.warnings.clone());
+    match refresh_target_document(&selected.target, timeout) {
+        Ok((title, current_url)) => {
+            navigated_target.title = title;
+            navigated_target.url = current_url;
+        }
+        Err(error) => {
+            warnings.push(format!(
+                "could not refresh browser target metadata after navigation; target.title/target.url may describe the previous page: {error}"
+            ));
+        }
+    }
     let page = if snapshot {
         Some(read_page_snapshot(
             &selected.target,
@@ -1028,8 +1044,6 @@ pub(crate) fn workspace_browser_navigate_from_status(
     } else {
         None
     };
-    let mut warnings = selected.targets.warnings.clone();
-    warnings.extend(selected.warnings.clone());
     let response = WorkspaceBrowserNavigate {
         ok: true,
         message: "workspace browser navigated through workspace-owned Chrome DevTools".to_string(),
@@ -1037,8 +1051,8 @@ pub(crate) fn workspace_browser_navigate_from_status(
         app_id: selected.targets.app_id.clone(),
         app_pid: selected.targets.app_pid,
         devtools_endpoint: selected.targets.devtools_endpoint.clone(),
-        target: Some(selected.target.clone()),
-        browser_target_id: Some(selected.target.id.clone()),
+        browser_target_id: Some(navigated_target.id.clone()),
+        target: Some(navigated_target),
         url,
         navigation: Some(navigation),
         page,
@@ -1135,6 +1149,22 @@ pub(crate) fn workspace_browser_click_from_status(
         timeout,
     )?;
     std::thread::sleep(Duration::from_millis(wait_ms.unwrap_or(250).min(30_000)));
+    // A click can navigate (links, SPA routing), so the pre-click target
+    // metadata may now describe the previous page. Refresh it.
+    let mut clicked_target = selected.target.clone();
+    let mut warnings = selected.targets.warnings.clone();
+    warnings.extend(selected.warnings.clone());
+    match refresh_target_document(&selected.target, timeout) {
+        Ok((title, current_url)) => {
+            clicked_target.title = title;
+            clicked_target.url = current_url;
+        }
+        Err(error) => {
+            warnings.push(format!(
+                "could not refresh browser target metadata after click; target.title/target.url may describe the previous page: {error}"
+            ));
+        }
+    }
     let page = if snapshot {
         Some(read_page_snapshot(
             &selected.target,
@@ -1144,8 +1174,6 @@ pub(crate) fn workspace_browser_click_from_status(
     } else {
         None
     };
-    let mut warnings = selected.targets.warnings.clone();
-    warnings.extend(selected.warnings.clone());
     Ok(WorkspaceBrowserClick {
         ok: true,
         message: "workspace browser clicked through workspace-owned Chrome DevTools".to_string(),
@@ -1153,8 +1181,8 @@ pub(crate) fn workspace_browser_click_from_status(
         app_id: selected.targets.app_id.clone(),
         app_pid: selected.targets.app_pid,
         devtools_endpoint: selected.targets.devtools_endpoint.clone(),
-        target: Some(selected.target.clone()),
-        browser_target_id: Some(selected.target.id.clone()),
+        browser_target_id: Some(clicked_target.id.clone()),
+        target: Some(clicked_target),
         click: Some(click),
         page,
         agent_mode: None,
@@ -1437,6 +1465,47 @@ fn page_target_candidates_summary(targets: &[BrowserTarget], limit: usize) -> St
 
 fn cdp_timeout(timeout_ms: Option<u64>) -> Duration {
     Duration::from_millis(timeout_ms.unwrap_or(5_000).clamp(100, 30_000))
+}
+
+/// Re-read `title`/`url` for a target after an action that changes the page.
+///
+/// `/json/list` metadata is captured when the target is *selected*, which is
+/// before navigation happens. Returning that stale copy makes
+/// `target.url`/`target.title` describe the previous page while `page.*`
+/// describes the new one — callers that assert on `target` silently validate
+/// the wrong document. Cheap `Runtime.evaluate`, independent of `snapshot`.
+fn refresh_target_document(target: &BrowserTarget, timeout: Duration) -> Result<(String, String)> {
+    let value = cdp_request(
+        target,
+        "Runtime.evaluate",
+        json!({
+            "expression": "JSON.stringify({ title: document.title, url: location.href })",
+            "returnByValue": true,
+            "awaitPromise": true,
+        }),
+        timeout,
+    )?;
+    if let Some(exception) = value.get("exceptionDetails") {
+        bail!("browser target refresh Runtime.evaluate failed: {exception}");
+    }
+    let raw = value
+        .get("result")
+        .and_then(|result| result.get("value"))
+        .and_then(serde_json::Value::as_str)
+        .context("browser target refresh Runtime.evaluate did not return a JSON value")?;
+    let parsed: serde_json::Value =
+        serde_json::from_str(raw).context("browser target refresh returned invalid JSON")?;
+    let title = parsed
+        .get("title")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or_default()
+        .to_string();
+    let url = parsed
+        .get("url")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or_default()
+        .to_string();
+    Ok((title, url))
 }
 
 fn read_page_snapshot(
@@ -2079,7 +2148,7 @@ fn select_browser_app(
             bail!("no running workspace browser app matched app id/name/pid {app_id:?}");
         }
         bail!(
-            "no running workspace browser app exposes --user-data-dir and Chrome DevTools; call workspace_open_browser or launch Chrome inside the workspace with --remote-debugging-address=127.0.0.1 --remote-debugging-port=0"
+            "no running workspace browser app exposes --user-data-dir and Chrome DevTools; call workspace_open_browser (MCP) or `agent-workspace-linux workspace open-browser` (CLI), or launch Chrome inside the workspace with --user-data-dir=DIR --remote-debugging-address=127.0.0.1 --remote-debugging-port=0. Note: the DevTools port is ephemeral, so external WebSocket clients must omit the Origin header (e.g. websocket-client's suppress_origin=True) rather than rely on --remote-allow-origins"
         );
     }
     if candidates.len() > 1 && app_id.is_none() && user_data_dir.is_none() {
@@ -2893,6 +2962,33 @@ mod tests {
         assert_eq!(detail["raw_result_text_omitted"], true);
         assert!(detail.get("results").is_none());
         assert!(detail.get("text_excerpt").is_none());
+    }
+
+    #[test]
+    fn workspace_browser_command_binds_devtools_to_loopback_without_widening_origins() {
+        // Chrome rejects DevTools WebSocket upgrades whose `Origin` header is not
+        // allow-listed, and it matches origins *including the port*. Because the
+        // endpoint uses `--remote-debugging-port=0` (ephemeral), no static
+        // `--remote-allow-origins` list can ever match — only `*` would, and that
+        // disables the CSRF protection guarding this endpoint. Verified: clients
+        // that omit `Origin` (the bundled CDP client, and any library with
+        // origin suppression) connect fine with no flag at all. So we bind to
+        // loopback and deliberately do NOT pass --remote-allow-origins.
+        let command = workspace_browser_command(
+            Path::new("/usr/bin/google-chrome"),
+            Path::new("/tmp/profile"),
+            "about:blank",
+        );
+        assert!(command
+            .iter()
+            .any(|arg| arg == "--remote-debugging-address=127.0.0.1"));
+        assert!(command.iter().any(|arg| arg == "--remote-debugging-port=0"));
+        assert!(
+            !command
+                .iter()
+                .any(|arg| arg.starts_with("--remote-allow-origins")),
+            "must not widen DevTools origins; document Origin suppression instead"
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -398,7 +398,7 @@ fn handle_workspace(
 ) -> Result<()> {
     let Some(command) = args.first().map(String::as_str) else {
         bail!(
-            "missing workspace command. Expected: start, open-profile, list, cleanup, status, manifest, artifacts, ipc-info, env, launch, run, launch-profile-apps, apps, browser-targets, browser-snapshot, browser-search-results, browser-navigate, windows, active-window, pointer, observe, wait-window, screenshot, screenshot-window, focus-window, close-window, move-window, resize-window, raise-window, minimize-window, show-window, click, click-window, move-pointer, move-pointer-window, drag, drag-window, scroll, scroll-window, key, key-window, type, type-window, clipboard-set, clipboard-get, paste, paste-window, logs, wait-app, events, setup, kill-app, stop"
+            "missing workspace command. Expected: start, open-profile, list, cleanup, status, manifest, artifacts, ipc-info, env, launch, run, launch-profile-apps, apps, open-browser, browser-targets, browser-snapshot, browser-search-results, browser-navigate, windows, active-window, pointer, observe, wait-window, screenshot, screenshot-window, focus-window, close-window, move-window, resize-window, raise-window, minimize-window, show-window, click, click-window, move-pointer, move-pointer-window, drag, drag-window, scroll, scroll-window, key, key-window, type, type-window, clipboard-set, clipboard-get, paste, paste-window, logs, wait-app, events, setup, kill-app, stop"
         );
     };
     match command {
@@ -531,6 +531,36 @@ fn handle_workspace(
                 parsed.profile_id,
                 parsed.running,
             )?)
+        }
+        "open-browser" => {
+            let parsed = parse_open_browser_options(&args[1..])?;
+            let plan = browser::workspace_browser_open_plan(
+                &parsed.id,
+                parsed.browser_path,
+                parsed.user_data_dir,
+                parsed.url,
+            )?;
+            permissions.validate_launch_spec(&plan.spec)?;
+            if parsed.dry_run {
+                print_json(&serde_json::json!({
+                    "ok": true,
+                    "message": "workspace open-browser dry run; no browser launched",
+                    "id": parsed.id,
+                    "dry_run": true,
+                    "browser_path": plan.browser_path,
+                    "user_data_dir": plan.user_data_dir,
+                    "url": plan.url,
+                    "command": plan.spec.command,
+                }))
+            } else {
+                print_json(&browser::workspace_open_browser(
+                    &parsed.id,
+                    plan,
+                    parsed.wait_window,
+                    parsed.window_timeout_ms,
+                    parsed.timeout_ms,
+                )?)
+            }
         }
         "browser-targets" => {
             let parsed = parse_browser_targets_options(&args[1..])?;
@@ -998,7 +1028,7 @@ fn handle_workspace(
         unknown => {
             bail!(
                 "unknown workspace command '{unknown}'. Expected: {}",
-                "start, open-profile, list, cleanup, status, manifest, artifacts, ipc-info, env, launch, run, launch-profile-apps, apps, browser-targets, browser-snapshot, browser-search-results, browser-navigate, windows, active-window, pointer, observe, wait-window, screenshot, screenshot-window, focus-window, close-window, move-window, resize-window, raise-window, minimize-window, show-window, click, click-window, move-pointer, move-pointer-window, drag, drag-window, scroll, scroll-window, key, key-window, type, type-window, clipboard-set, clipboard-get, paste, paste-window, logs, wait-app, events, setup, kill-app, stop"
+                "start, open-profile, list, cleanup, status, manifest, artifacts, ipc-info, env, launch, run, launch-profile-apps, apps, open-browser, browser-targets, browser-snapshot, browser-search-results, browser-navigate, windows, active-window, pointer, observe, wait-window, screenshot, screenshot-window, focus-window, close-window, move-window, resize-window, raise-window, minimize-window, show-window, click, click-window, move-pointer, move-pointer-window, drag, drag-window, scroll, scroll-window, key, key-window, type, type-window, clipboard-set, clipboard-get, paste, paste-window, logs, wait-app, events, setup, kill-app, stop"
             )
         }
     }
@@ -1305,6 +1335,85 @@ struct ParsedBrowserNavigateOptions {
     snapshot: bool,
     max_text_chars: Option<usize>,
     timeout_ms: Option<u64>,
+}
+
+#[derive(Debug)]
+struct ParsedOpenBrowserOptions {
+    id: String,
+    browser_path: Option<PathBuf>,
+    user_data_dir: Option<PathBuf>,
+    url: Option<String>,
+    wait_window: bool,
+    window_timeout_ms: Option<u64>,
+    timeout_ms: Option<u64>,
+    dry_run: bool,
+}
+
+fn parse_open_browser_options(args: &[String]) -> Result<ParsedOpenBrowserOptions> {
+    let mut id = workspace::default_workspace_id();
+    let mut browser_path = None;
+    let mut user_data_dir = None;
+    let mut url = None;
+    let mut wait_window = true;
+    let mut window_timeout_ms = None;
+    let mut timeout_ms = None;
+    let mut dry_run = false;
+    let mut index = 0;
+    while index < args.len() {
+        match args[index].as_str() {
+            "--id" => {
+                id = value_after(args, index, "--id")?.to_string();
+                index += 2;
+            }
+            "--browser" | "--browser-path" => {
+                browser_path = Some(PathBuf::from(value_after(args, index, "--browser")?));
+                index += 2;
+            }
+            "--user-data-dir" => {
+                user_data_dir = Some(PathBuf::from(value_after(args, index, "--user-data-dir")?));
+                index += 2;
+            }
+            "--no-wait-window" => {
+                wait_window = false;
+                index += 1;
+            }
+            "--window-timeout-ms" => {
+                window_timeout_ms = Some(
+                    value_after(args, index, "--window-timeout-ms")?
+                        .parse()
+                        .context("--window-timeout-ms must be a non-negative integer")?,
+                );
+                index += 2;
+            }
+            "--timeout-ms" => {
+                timeout_ms = Some(
+                    value_after(args, index, "--timeout-ms")?
+                        .parse()
+                        .context("--timeout-ms must be a non-negative integer")?,
+                );
+                index += 2;
+            }
+            "--dry-run" => {
+                dry_run = true;
+                index += 1;
+            }
+            value if !value.starts_with('-') && url.is_none() => {
+                url = Some(value.to_string());
+                index += 1;
+            }
+            flag => bail!("unknown workspace open-browser option '{flag}'"),
+        }
+    }
+    Ok(ParsedOpenBrowserOptions {
+        id,
+        browser_path,
+        user_data_dir,
+        url,
+        wait_window,
+        window_timeout_ms,
+        timeout_ms,
+        dry_run,
+    })
 }
 
 fn parse_browser_targets_options(args: &[String]) -> Result<ParsedBrowserTargetsOptions> {
@@ -4359,6 +4468,78 @@ them as ordinary controllable windows.
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn args(values: &[&str]) -> Vec<String> {
+        values.iter().map(|value| value.to_string()).collect()
+    }
+
+    #[test]
+    fn open_browser_options_take_url_positionally_with_defaults() {
+        let parsed = parse_open_browser_options(&args(&["http://127.0.0.1:8111/lesson/1"]))
+            .expect("parse open-browser options");
+        assert_eq!(
+            parsed.url.as_deref(),
+            Some("http://127.0.0.1:8111/lesson/1")
+        );
+        assert!(parsed.wait_window, "should wait for the window by default");
+        assert!(!parsed.dry_run);
+        assert!(parsed.browser_path.is_none());
+    }
+
+    #[test]
+    fn open_browser_options_accept_flags_and_dry_run() {
+        let parsed = parse_open_browser_options(&args(&[
+            "--id",
+            "qa",
+            "--browser",
+            "/usr/bin/chromium",
+            "--user-data-dir",
+            "/tmp/qa-profile",
+            "--no-wait-window",
+            "--timeout-ms",
+            "9000",
+            "--dry-run",
+            "about:blank",
+        ]))
+        .expect("parse open-browser options");
+        assert_eq!(parsed.id, "qa");
+        assert_eq!(
+            parsed.browser_path,
+            Some(PathBuf::from("/usr/bin/chromium"))
+        );
+        assert_eq!(parsed.user_data_dir, Some(PathBuf::from("/tmp/qa-profile")));
+        assert_eq!(parsed.url.as_deref(), Some("about:blank"));
+        assert!(!parsed.wait_window);
+        assert_eq!(parsed.timeout_ms, Some(9_000));
+        assert!(parsed.dry_run);
+    }
+
+    #[test]
+    fn open_browser_options_reject_unknown_flags() {
+        let error = parse_open_browser_options(&args(&["--bogus"]))
+            .expect_err("unknown flags must be rejected");
+        assert!(
+            error.to_string().contains("open-browser"),
+            "error should name the subcommand: {error}"
+        );
+    }
+
+    #[test]
+    fn unknown_workspace_command_advertises_open_browser() {
+        // The browser-attach failure hint tells callers to run
+        // `workspace open-browser`; it must appear in the dispatch command list
+        // so the suggestion is discoverable instead of looking unsupported.
+        let error = handle_workspace(
+            args(&["definitely-not-a-command"]),
+            &permissions::McpPermissionState::default(),
+        )
+        .expect_err("unknown workspace command must error");
+        let message = error.to_string();
+        assert!(
+            message.contains("open-browser"),
+            "unknown-command help must list open-browser: {message}"
+        );
+    }
 
     fn assert_open_mcp_permissions(state: &permissions::McpPermissionState) {
         assert!(!state.restricted);


### PR DESCRIPTION
## Summary

`browser_navigate` and `browser_click` returned the `BrowserTarget` captured by `select_browser_target_from_status()`, which runs **before** the action. So `target.url` / `target.title` described the *previous* page while `page.url` / `page.title` described the new one.

This is worse than an error — it reports confidently wrong data. `target.title` is the natural field to assert on when verifying a navigation, so a caller that trusts it validates the page it just left. Found while using the workspace to QA a local web app: it caused a wrong conclusion (an app bug was nearly filed that didn't exist).

**Reproduced deterministically** — off-by-one on *every* navigation, not a timing race (`--wait-ms 6000` was still stale):

| requested | `target.url` (before) | `page.url` |
|---|---|---|
| `/lesson/40` | `/lesson/1` ← stale | `/lesson/40` ✓ |
| `/lesson/41` | `/lesson/40` ← stale | `/lesson/41` ✓ |
| `/lesson/42` | `/lesson/41` ← stale | `/lesson/42` ✓ |

Both the daemon IPC path and the direct-CDP fallback converge on `*_from_status`, so both were affected. `browser_snapshot` was already correct (it doesn't mutate the page).

## Changes

- **`refresh_target_document()`** — cheap `Runtime.evaluate` reading `document.title` / `location.href` after the action, independent of `snapshot`. Wired into **both** mutating paths (`navigate` and `click` — a click that follows a link had the same flaw). On failure the response gains a `warnings` entry instead of silently returning stale metadata.
- **`workspace open-browser` CLI subcommand** — the browser-attach failure hint told callers to *"call `workspace_open_browser`"*, which was only reachable over MCP; anyone driving the CLI hit a dead end. Mirrors the MCP handler including `permissions.validate_launch_spec`, supports `--dry-run` to inspect the argv, and is listed in the workspace command help so the suggestion is discoverable.
- **Docs** (README + bundled skill) for the browser flow and the `Origin` caveat below.

## Why `--remote-allow-origins` is deliberately NOT set

Worth recording, because it looks like a missing flag. Attaching a normal WebSocket client to the workspace DevTools endpoint fails with `403 Forbidden`. I first "fixed" this by adding `--remote-allow-origins=http://127.0.0.1,http://localhost` — **it still 403'd.** Root cause:

- Chrome matches `Origin` **including the port**
- the endpoint uses `--remote-debugging-port=0` (**ephemeral**)
- therefore no static allow-list value can ever match; only `*` would, and that disables the CSRF protection guarding the endpoint

Verified directly: with a portless allow-list a portless `Origin` connects, an `Origin` carrying the real port is rejected, and a hostile origin stays rejected. Critically, a client that **omits** `Origin` connects fine with **no flag at all** — which is why the bundled CDP client (hand-rolled handshake, no `Origin`) never tripped this.

So the flag was reverted and the fix is documentation:

```python
ws = websocket.create_connection(ws_debugger_url, suppress_origin=True)
```

A test asserts the argv must **not** grow `--remote-allow-origins`, so this doesn't get "helpfully" re-added later.

## Test plan

- `cargo test --all-targets` → **177 passed, 0 failed** (5 new: CLI parser defaults / flags+dry-run / unknown-flag rejection, command-list discoverability, argv-must-not-widen-origins)
- `cargo fmt --all -- --check` ✓
- `cargo clippy --all-targets -- -D warnings` ✓
- **E2E against a release build**, isolated workspace on display `:90`: 5/5 navigations report matching `target`/`page` (`/lesson/{40,41,42,7,60}`); `open-browser --dry-run` shows correct argv; clean-slate `open-browser` returns `ok: true`; click-induced navigation confirmed stale *without* the refresh (`/lesson/1` → `/`), which the fix corrects
- Workspace torn down after verification; host Chrome untouched