### PR TITLE
fix(server): add MCP 2026-07-28 support

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -10068,6 +10068,7 @@ mod tests {
     use super::*;
     use rmcp::ServerHandler;
     use std::fs;
+    use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 
     #[test]
     fn mcp_server_version_matches_crate_version() {
@@ -10078,6 +10079,70 @@ mod tests {
         let info = AgentWorkspaceLinux::default().get_info();
         assert_eq!(info.server_info.version, env!("CARGO_PKG_VERSION"));
         assert_eq!(info.server_info.name, "agent-workspace-linux");
+    }
+
+    #[tokio::test]
+    async fn tools_list_sets_required_cache_metadata() {
+        let (server_transport, client_transport) = tokio::io::duplex(64 * 1024);
+        let server_handle = tokio::spawn(async move {
+            AgentWorkspaceLinux::default()
+                .serve(server_transport)
+                .await
+                .expect("server should start")
+                .waiting()
+                .await
+                .expect("server should stop cleanly");
+        });
+
+        let (client_read, mut client_write) = tokio::io::split(client_transport);
+        let mut client_read = BufReader::new(client_read);
+        client_write
+            .write_all(
+                br#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2026-07-28","capabilities":{},"clientInfo":{"name":"test-client","version":"1"}}}
+"#,
+            )
+            .await
+            .expect("initialize request should be written");
+
+        let mut response = String::new();
+        client_read
+            .read_line(&mut response)
+            .await
+            .expect("initialize response should be read");
+        let response: serde_json::Value =
+            serde_json::from_str(&response).expect("initialize response should be JSON");
+        assert_eq!(response["id"], 1);
+
+        client_write
+            .write_all(
+                br#"{"jsonrpc":"2.0","method":"notifications/initialized"}
+{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}
+"#,
+            )
+            .await
+            .expect("tools/list request should be written");
+
+        let mut response = String::new();
+        client_read
+            .read_line(&mut response)
+            .await
+            .expect("tools/list response should be read");
+        let response: serde_json::Value =
+            serde_json::from_str(&response).expect("tools/list response should be JSON");
+
+        assert_eq!(response["id"], 2);
+        assert!(
+            response["result"].get("ttlMs").is_some(),
+            "tools/list should set ttlMs"
+        );
+        assert!(
+            response["result"].get("cacheScope").is_some(),
+            "tools/list should set cacheScope"
+        );
+
+        drop(client_read);
+        drop(client_write);
+        server_handle.await.expect("server task should finish");
     }
 
     fn catalog_tool<'a>(catalog: &'a McpActionCatalog, name: &str) -> &'a McpActionInfo {

--- a/src/server.rs
+++ b/src/server.rs
@@ -19,6 +19,13 @@ use rmcp::{
 use serde::{Deserialize, Serialize};
 use std::{collections::BTreeSet, path::PathBuf};
 
+/// How long clients may treat a `tools/list` result as fresh (SEP-2549).
+///
+/// The advertised tool set comes from the static `tool_router()`, and control
+/// mode and the permission ceiling are enforced when a tool is called rather
+/// than by filtering this list, so it cannot go stale while the process lives.
+const TOOLS_LIST_TTL_MS: u64 = 3_600_000;
+
 #[derive(Clone, Default)]
 pub struct AgentWorkspaceLinux {
     permissions: McpPermissionState,
@@ -3134,7 +3141,7 @@ impl ServerHandler for AgentWorkspaceLinux {
             sanitize_tool_schema(tool);
         }
         Ok(rmcp::model::ListToolsResult::with_all_items(tools)
-            .with_ttl_ms(3_600_000)
+            .with_ttl_ms(TOOLS_LIST_TTL_MS)
             .with_cache_scope(CacheScope::Private))
     }
 
@@ -10068,7 +10075,7 @@ mod tests {
     use super::*;
     use rmcp::ServerHandler;
     use std::fs;
-    use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+    use tokio::io::{AsyncBufRead, AsyncBufReadExt, AsyncWriteExt, BufReader};
 
     #[test]
     fn mcp_server_version_matches_crate_version() {
@@ -10081,8 +10088,27 @@ mod tests {
         assert_eq!(info.server_info.name, "agent-workspace-linux");
     }
 
-    #[tokio::test]
-    async fn tools_list_sets_required_cache_metadata() {
+    /// Read frames until the response for `id` arrives, skipping notifications
+    /// and anything else the server may interleave ahead of it.
+    async fn read_response<R: AsyncBufRead + Unpin>(reader: &mut R, id: u64) -> serde_json::Value {
+        loop {
+            let mut line = String::new();
+            let read = reader
+                .read_line(&mut line)
+                .await
+                .expect("server frame should be read");
+            assert!(read > 0, "server closed before responding to id {id}");
+            let frame: serde_json::Value =
+                serde_json::from_str(&line).expect("server frame should be JSON");
+            if frame["id"].as_u64() == Some(id) {
+                return frame;
+            }
+        }
+    }
+
+    /// Drive initialize plus `tools/list` against an in-process server on the
+    /// given protocol version and return the `tools/list` result object.
+    async fn tools_list_result(protocol_version: &str) -> serde_json::Value {
         let (server_transport, client_transport) = tokio::io::duplex(64 * 1024);
         let server_handle = tokio::spawn(async move {
             AgentWorkspaceLinux::default()
@@ -10098,20 +10124,19 @@ mod tests {
         let mut client_read = BufReader::new(client_read);
         client_write
             .write_all(
-                br#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2026-07-28","capabilities":{},"clientInfo":{"name":"test-client","version":"1"}}}
-"#,
+                format!(
+                    r#"{{"jsonrpc":"2.0","id":1,"method":"initialize","params":{{"protocolVersion":"{protocol_version}","capabilities":{{}},"clientInfo":{{"name":"test-client","version":"1"}}}}}}
+"#
+                )
+                .as_bytes(),
             )
             .await
             .expect("initialize request should be written");
-
-        let mut response = String::new();
-        client_read
-            .read_line(&mut response)
-            .await
-            .expect("initialize response should be read");
-        let response: serde_json::Value =
-            serde_json::from_str(&response).expect("initialize response should be JSON");
-        assert_eq!(response["id"], 1);
+        let initialized = read_response(&mut client_read, 1).await;
+        assert_eq!(
+            initialized["result"]["protocolVersion"], protocol_version,
+            "server should negotiate the requested protocol version"
+        );
 
         client_write
             .write_all(
@@ -10121,28 +10146,52 @@ mod tests {
             )
             .await
             .expect("tools/list request should be written");
-
-        let mut response = String::new();
-        client_read
-            .read_line(&mut response)
-            .await
-            .expect("tools/list response should be read");
-        let response: serde_json::Value =
-            serde_json::from_str(&response).expect("tools/list response should be JSON");
-
-        assert_eq!(response["id"], 2);
-        assert!(
-            response["result"].get("ttlMs").is_some(),
-            "tools/list should set ttlMs"
-        );
-        assert!(
-            response["result"].get("cacheScope").is_some(),
-            "tools/list should set cacheScope"
-        );
+        let listed = read_response(&mut client_read, 2).await;
 
         drop(client_read);
         drop(client_write);
-        server_handle.await.expect("server task should finish");
+        // Bounded so a server that stops shutting down on client disconnect
+        // fails the test instead of hanging the run.
+        tokio::time::timeout(std::time::Duration::from_secs(10), server_handle)
+            .await
+            .expect("server task should finish after the client disconnects")
+            .expect("server task should not panic");
+
+        listed["result"].clone()
+    }
+
+    #[tokio::test]
+    async fn tools_list_sets_required_cache_metadata() {
+        let result = tools_list_result("2026-07-28").await;
+
+        // SEP-2549 requires both fields at 2026-07-28, and asserting the values
+        // rather than their presence keeps a `ttlMs: 0` regression — present on
+        // the wire but useless to a client — from passing this test.
+        assert_eq!(result["ttlMs"].as_u64(), Some(TOOLS_LIST_TTL_MS));
+        assert_eq!(result["cacheScope"], "private");
+        // SEP-2322.
+        assert_eq!(result["resultType"], "complete");
+        assert!(
+            !result["tools"]
+                .as_array()
+                .expect("tools should be an array")
+                .is_empty(),
+            "tools/list should advertise the tool set"
+        );
+    }
+
+    #[tokio::test]
+    async fn tools_list_keeps_legacy_wire_shape() {
+        let result = tools_list_result("2025-06-18").await;
+
+        // Peers older than 2026-07-28 keep the legacy shape: rmcp strips
+        // `resultType`, while the cache fields stay as ignorable extras.
+        assert!(
+            result.get("resultType").is_none(),
+            "legacy peers should not receive resultType: {result}"
+        );
+        assert_eq!(result["ttlMs"].as_u64(), Some(TOOLS_LIST_TTL_MS));
+        assert_eq!(result["cacheScope"], "private");
     }
 
     fn catalog_tool<'a>(catalog: &'a McpActionCatalog, name: &str) -> &'a McpActionInfo {

--- a/src/server.rs
+++ b/src/server.rs
@@ -12,6 +12,7 @@ use crate::workspace::{
 use anyhow::{bail, Result};
 use rmcp::{
     handler::server::wrapper::{Json, Parameters},
+    model::CacheScope,
     schemars::JsonSchema,
     tool, tool_handler, tool_router, ServerHandler, ServiceExt,
 };
@@ -3132,7 +3133,9 @@ impl ServerHandler for AgentWorkspaceLinux {
         for tool in &mut tools {
             sanitize_tool_schema(tool);
         }
-        Ok(rmcp::model::ListToolsResult::with_all_items(tools))
+        Ok(rmcp::model::ListToolsResult::with_all_items(tools)
+            .with_ttl_ms(0)
+            .with_cache_scope(CacheScope::Private))
     }
 
     fn get_tool(&self, name: &str) -> Option<rmcp::model::Tool> {

--- a/src/server.rs
+++ b/src/server.rs
@@ -3134,7 +3134,7 @@ impl ServerHandler for AgentWorkspaceLinux {
             sanitize_tool_schema(tool);
         }
         Ok(rmcp::model::ListToolsResult::with_all_items(tools)
-            .with_ttl_ms(0)
+            .with_ttl_ms(3_600_000)
             .with_cache_scope(CacheScope::Private))
     }
 


### PR DESCRIPTION
## Summary

Adds new fields that are mandatory in the MCP 2026-07-28 protocol, fixing tool discovery in Claude Code.

Closes #68.

## Checklist

- [x] `cargo fmt --check` passes
- [x] `cargo clippy --locked -- -D warnings` passes
- [x] `cargo test --locked` passes
- [x] `git diff --check` is clean (no trailing whitespace / conflict markers)
- [ ] `scripts/integration_smoke.sh` run for changes touching runtime behavior (MCP tools, permissions, workspace control, viewer, browser) — or N/A
- [x] No secrets, credentials, personal data, or machine-specific absolute paths added
- [x] Docs updated if behavior, flags, or the permission/trust model changed

## Notes for reviewers

Without this change, the issue described in #68 occurs. After implementing this change, Claude Code successfully discovers 82 tools from agent-workspace-linux.

`scripts/integration_smoke.sh` seems to fail on something unrelated:

<details>
<summary>Logs</summary>

```
   Compiling agent-workspace-linux v0.3.1 (/home/luna/src/agent-workspace-linux.worktrees/fix-mcp-2026-07-28-support)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 31.86s
== mcp permissions smoke ==
mcp permissions smoke passed
== non-headless mcp viewer smoke ==
Error: non-headless app QA plan should expose viewer availability: {"version":1,"requested_intent":"app QA","normalized_intent":"app_qa","summary":"Plan for project or desktop app QA in an isolated workspace.","recommended_profile_kind":"project-dev","headless":false,"host_viewer_ready":false,"viewer_available":false,"viewer_unavailable_reason":"Host-visible viewer steps are omitted because workspace_doctor.ready_for_host_viewer=false; start the MCP from a desktop session with DISPLAY or WAYLAND_DISPLAY to enable the viewer.","permissions":{"configured":false,"restricted":false,"ceiling":{"apps":{}},"message":"No MCP permission ceiling is configured; the host/client session controls workspace permissions, including full-access sessions after hidden-workspace approval."},"control":{"mode":"active","allows_agent_mutation":true,"message":"MCP live control is active"},"task_context":{"task_kind":"app_qa","workspace_id":"default","provided_inputs":[{"name":"project_path","value":"/home/luna/src/agent-workspace-linux.worktrees/fix-mcp-2026-07-28-support"}],"action_boundaries":[{"id":"observe_project_state","label":"Observe project state","action_type":"read_only_observation","ready":true,"approval_required":false,"approved":true,"reason":"Screenshots, app/window listing, logs, and workspace events are safe first steps before app input."},{"id":"start_or_attach_project_workspace","label":"Start or attach project workspace","action_type":"hidden_workspace_start","ready":true,"approval_required":true,"approved":false,"approval_kind":"hidden_workspace","reason":"A fresh app-QA run needs a saved profile or project_path plus hidden-workspace approval; an already-running workspace can be observed without starting another one."},{"id":"collect_qa_evidence","label":"Collect QA evidence","action_type":"read_only_evidence","ready":false,"approval_required":false,"approved":true,"required_inputs":["running_workspace"],"reason":"After the workspace is running, collect events, logs, and targeted screenshots before driving the app or reporting results."},{"id":"drive_workspace_app","label":"Drive workspace app","action_type":"workspace_input","ready":false,"approval_required":false,"approved":true,"required_inputs":["running_workspace","stable_app_id_or_window"],"reason":"Keyboard, pointer, clipboard, and window actions are scoped to the isolated workspace, but they should wait for observation and a stable app/window target."},{"id":"write_mounted_project_files","label":"Write mounted project files","action_type":"project_file_mutation","ready":false,"approval_required":true,"approved":false,"approval_kind":"project_file_write","required_inputs":["explicit_code_change_request"],"reason":"Changing files in a mounted project is separate from observing or driving the app; do it only when the user asked for code/file changes."}],"approval_kinds":["hidden_workspace","preview_surface","profile_write","project_file_write","required_input"]},"assumptions":["Host-visible viewer steps are omitted because workspace_doctor.ready_for_host_viewer=false; start the MCP from a desktop session with DISPLAY or WAYLAND_DISPLAY to enable the viewer."],"approval_checkpoints":[{"id":"dry_run_save_project_profile:required_input","step_id":"dry_run_save_project_profile","order":3,"kind":"required_input","label":"Collect required user input","tool":"profile_put","approval_required":true,"blocks_step":true,"approval_hint":"Preview only; the real save is mutating and should follow user review.","required_input":["Use the WorkspaceProfile object returned by template_project_profile as the profile argument."]},{"id":"dry_run_save_project_profile:preview_surface","step_id":"dry_run_save_project_profile","order":3,"kind":"preview_surface","label":"Use preview as approval surface","tool":"profile_put","approval_required":false,"blocks_step":false,"approval_hint":"Preview only; the real save is mutating and should follow user review."},{"id":"save_project_profile_after_review:required_input","step_id":"save_project_profile_after_review","order":4,"kind":"required_input","label":"Collect required user input","tool":"profile_put","approval_required":true,"blocks_step":true,"approval_hint":"Mutating profile write; requires explicit approval and active live control.","required_input":["Use the same WorkspaceProfile object from template_project_profile after the user approves the dry-run result."]},{"id":"save_project_profile_after_review:profile_write","step_id":"save_project_profile_after_review","order":4,"kind":"profile_write","label":"Approve profile write","tool":"profile_put","approval_required":true,"blocks_step":true,"approval_hint":"Mutating profile write; requires explicit approval and active live control."},{"id":"run_project_profile_after_save:required_input","step_id":"run_project_profile_after_save","order":5,"kind":"required_input","label":"Collect required user input","tool":"workspace_open_profile","approval_required":true,"blocks_step":true,"approval_hint":"Mutating; requires hidden-workspace approval and active live control.","required_input":["Run only after profile_put saves the project-dev profile successfully."]},{"id":"run_project_profile_after_save:hidden_workspace","step_id":"run_project_profile_after_save","order":5,"kind":"hidden_workspace","label":"Approve hidden workspace","tool":"workspace_open_profile","approval_required":true,"blocks_step":true,"approval_hint":"Mutating; requires hidden-workspace approval and active live control."},{"id":"observe_project_workspace:required_input","step_id":"observe_project_workspace","order":6,"kind":"required_input","label":"Collect required user input","tool":"workspace_observe","approval_required":true,"blocks_step":true,"approval_hint":"Read-only observation; no user approval required after the workspace exists.","required_input":["Call after the project QA workspace has started."]},{"id":"list_project_apps_after_start:required_input","step_id":"list_project_apps_after_start","order":7,"kind":"required_input","label":"Collect required user input","tool":"workspace_list_apps","approval_required":true,"blocks_step":true,"approval_hint":"Read-only inspection; no user approval required after the workspace exists.","required_input":["Call after observe_project_workspace succeeds."]},{"id":"read_project_events_after_start:required_input","step_id":"read_project_events_after_start","order":8,"kind":"required_input","label":"Collect required user input","tool":"workspace_events","approval_required":true,"blocks_step":true,"approval_hint":"Read-only event inspection; no user approval required after the workspace exists.","required_input":["Call after observe_project_workspace succeeds."]},{"id":"read_project_app_log_after_start:required_input","step_id":"read_project_app_log_after_start","order":9,"kind":"required_input","label":"Collect required user input","tool":"workspace_read_app_log","approval_required":true,"blocks_step":true,"approval_hint":"Read-only log inspection; no user approval required after a target app_id is known.","required_input":["Use a stable app_id from list_project_apps_after_start or observe_project_workspace."]},{"id":"capture_project_window_after_start:required_input","step_id":"capture_project_window_after_start","order":10,"kind":"required_input","label":"Collect required user input","tool":"workspace_screenshot_window","approval_required":true,"blocks_step":true,"approval_hint":"Read-only screenshot; no user approval required after a target is known.","required_input":["Use active_window.id or a stable app_id from observe_project_workspace/list_project_apps_after_start."]}],"approval_summary":{"blocking_count":10,"approval_required_count":10,"approval_kinds":["hidden_workspace","preview_surface","profile_write","project_file_write","required_input"],"next_boundary":{"kind":"required_input","label":"Collect required user input","step_id":"dry_run_save_project_profile","tool":"profile_put","blocks_step":true,"approval_required":true,"approval_hint":"Preview only; the real save is mutating and should follow user review.","required_input":["Use the WorkspaceProfile object returned by template_project_profile as the profile argument."]}},"steps":[{"id":"orient_session","order":1,"label":"Read the current session brief","tool":"mcp_session_brief","arguments":{},"ready_to_call":true,"reason":"Start from the live permission ceiling, control mode, runtime readiness, and known workspace/profile state.","approval_hint":"Read-only; no user approval required.","read_only":true,"mutating":false,"destructive":false,"open_world":false,"blocked_by_live_control":false},{"id":"template_project_profile","order":2,"label":"Generate a project QA profile template","tool":"profile_template","arguments":{"kind":"project-dev","id":"project-dev","host_path":"/home/luna/src/agent-workspace-linux.worktrees/fix-mcp-2026-07-28-support"},"ready_to_call":true,"reason":"No saved project profile was found, but a project path was provided.","approval_hint":"Read-only template generation; save it only after review.","read_only":true,"mutating":false,"destructive":false,"open_world":false,"blocked_by_live_control":false},{"id":"dry_run_save_project_profile","order":3,"label":"Dry-run saving the generated profile","tool":"profile_put","arguments":{"dry_run":true,"profile":null},"ready_to_call":false,"reason":"Dry-run the generated profile save so the UI can show whether it creates or replaces a profile.","approval_hint":"Preview only; the real save is mutating and should follow user review.","read_only":true,"mutating":false,"destructive":false,"open_world":false,"blocked_by_live_control":false,"depends_on":["template_project_profile"],"required_input":["Use the WorkspaceProfile object returned by template_project_profile as the profile argument."]},{"id":"save_project_profile_after_review","order":4,"label":"Save the reviewed project QA profile","tool":"profile_put","arguments":{"profile":null},"ready_to_call":false,"reason":"Call only after the user reviews the project mount, setup/startup commands, network behavior, and dry-run save result.","approval_hint":"Mutating profile write; requires explicit approval and active live control.","read_only":false,"mutating":true,"destructive":false,"open_world":false,"blocked_by_live_control":false,"depends_on":["dry_run_save_project_profile"],"required_input":["Use the same WorkspaceProfile object from template_project_profile after the user approves the dry-run result."]},{"id":"run_project_profile_after_save","order":5,"label":"Run the saved project QA profile","tool":"workspace_open_profile","arguments":{"id":"default","profile":"project-dev","acknowledge_hidden_workspace":true,"acknowledge_unenforced_policy":true,"purpose":"Project QA","setup":true,"setup_timeout_ms":30000,"setup_kill_on_timeout":true,"startup_wait_window":true,"startup_screenshot_window":true},"ready_to_call":false,"reason":"Call only after the generated project-dev profile has been saved and approved for this QA task.","approval_hint":"Mutating; requires hidden-workspace approval and active live control.","read_only":false,"mutating":true,"destructive":false,"open_world":false,"blocked_by_live_control":false,"depends_on":["save_project_profile_after_review"],"required_input":["Run only after profile_put saves the project-dev profile successfully."]},{"id":"observe_project_workspace","order":6,"label":"Observe the project QA workspace after it starts","tool":"workspace_observe","arguments":{"id":"default","screenshot":true,"include_events":true,"events_tail":20},"ready_to_call":false,"reason":"Once the project workspace is running, inspect screen, active window, app state, and events before driving the app under test.","approval_hint":"Read-only observation; no user approval required after the workspace exists.","read_only":true,"mutating":false,"destructive":false,"open_world":false,"blocked_by_live_control":false,"depends_on":["run_project_profile_after_save"],"required_input":["Call after the project QA workspace has started."]},{"id":"list_project_apps_after_start","order":7,"label":"List project QA apps after start","tool":"workspace_list_apps","arguments":{"id":"default","running":true},"ready_to_call":false,"reason":"After the project workspace starts, identify app ids and process labels so later actions can use stable app_id targets.","approval_hint":"Read-only inspection; no user approval required after the workspace exists.","read_only":true,"mutating":false,"destructive":false,"open_world":false,"blocked_by_live_control":false,"depends_on":["observe_project_workspace"],"required_input":["Call after observe_project_workspace succeeds."]},{"id":"read_project_events_after_start","order":8,"label":"Read project QA events after start","tool":"workspace_events","arguments":{"id":"default","tail":50},"ready_to_call":false,"reason":"After the project workspace starts, read recent workspace-local events before UI input or reporting.","approval_hint":"Read-only event inspection; no user approval required after the workspace exists.","read_only":true,"mutating":false,"destructive":false,"open_world":false,"blocked_by_live_control":false,"depends_on":["observe_project_workspace"],"required_input":["Call after observe_project_workspace succeeds."]},{"id":"read_project_app_log_after_start","order":9,"label":"Read project app log after app id is known","tool":"workspace_read_app_log","arguments":{"id":"default","app_id":null,"stream":"stdout","tail_bytes":12000},"ready_to_call":false,"reason":"Once a relevant app_id is known, inspect captured stdout before driving the UI or reporting QA evidence.","approval_hint":"Read-only log inspection; no user approval required after a target app_id is known.","read_only":true,"mutating":false,"destructive":false,"open_world":false,"blocked_by_live_control":false,"depends_on":["list_project_apps_after_start"],"required_input":["Use a stable app_id from list_project_apps_after_start or observe_project_workspace."]},{"id":"capture_project_window_after_start","order":10,"label":"Capture the project app window after target is known","tool":"workspace_screenshot_window","arguments":{"id":"default","app_id":null,"window_id":null},"ready_to_call":false,"reason":"After observation identifies an active window or app_id, capture that window as focused QA evidence before interacting.","approval_hint":"Read-only screenshot; no user approval required after a target is known.","read_only":true,"mutating":false,"destructive":false,"open_world":false,"blocked_by_live_control":false,"depends_on":["observe_project_workspace"],"required_input":["Use active_window.id or a stable app_id from observe_project_workspace/list_project_apps_after_start."]}]}
    at fail (/home/luna/src/agent-workspace-linux.worktrees/fix-mcp-2026-07-28-support/scripts/mcp_non_headless_viewer_smoke.js:84:9)
    at assert (/home/luna/src/agent-workspace-linux.worktrees/fix-mcp-2026-07-28-support/scripts/mcp_non_headless_viewer_smoke.js:133:19)
    at main (/home/luna/src/agent-workspace-linux.worktrees/fix-mcp-2026-07-28-support/scripts/mcp_non_headless_viewer_smoke.js:292:3)
    at process.processTicksAndRejections (node:internal/process/task_queues:104:5)
```

</details>