### PR TITLE
test(smoke): skip the non-headless viewer smoke without a host display

### DIFF
--- a/scripts/mcp_non_headless_viewer_smoke.js
+++ b/scripts/mcp_non_headless_viewer_smoke.js
@@ -15,6 +15,21 @@ if (!fs.existsSync(bin)) {
   throw new Error(`agent-workspace-linux binary not found at ${bin}; run cargo build first`);
 }
 
+// Everything below asserts the shape of a session that can open a host-visible
+// viewer: ready_for_host_viewer=true, viewer steps present in the task plan,
+// auto-open on workspace_start. On a machine with no host display the MCP is
+// right to report the viewer unavailable, so running these assertions there only
+// produces a failure that says nothing about the code — which is exactly what a
+// headless contributor hit on #69. mcp_no_host_display_viewer_smoke.js is the
+// smoke that covers that session shape. Empty is absent, matching the
+// non-empty-var check in host_display_check().
+if (!process.env.DISPLAY && !process.env.WAYLAND_DISPLAY) {
+  console.log(
+    "non-headless mcp viewer smoke skipped: no DISPLAY or WAYLAND_DISPLAY (run it from a desktop session)",
+  );
+  process.exit(0);
+}
+
 const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-workspace-non-headless-mcp-smoke-"));
 const configDir = path.join(tempDir, "config");
 const runtimeDir = path.join(tempDir, "runtime");


### PR DESCRIPTION
## Summary

`scripts/mcp_non_headless_viewer_smoke.js` asserts the shape of a session that *can* open a host-visible viewer — `ready_for_host_viewer=true`, viewer steps present in the task plan, auto-open on `workspace_start`. With no `DISPLAY` and no `WAYLAND_DISPLAY` the MCP is correct to report the viewer unavailable, so on a headless machine the script could only fail, and it failed on the first assertion with a wall of task-plan JSON that says nothing about the change under test.

A contributor running `scripts/integration_smoke.sh` on a headless box hit exactly that on #69 and reasonably read it as a failure in their own work.

Skips with a one-line reason instead, matching `mcp_terminal_tui_smoke.js` and `mcp_workspace_browser_cdp_smoke.js`. Empty string counts as absent, mirroring the non-empty check in `host_display_check()`. `mcp_no_host_display_viewer_smoke.js` already covers the session shape a headless machine can assert, so no coverage is lost — on a desktop session both still run.

## Checklist

- [x] `cargo fmt --check` passes — N/A, no Rust change
- [x] `cargo clippy --locked -- -D warnings` passes — N/A, no Rust change
- [x] `cargo test --locked` passes — N/A, no Rust change
- [x] `git diff --check` is clean
- [x] `scripts/integration_smoke.sh` — the affected script exercised directly, both paths
- [x] No secrets, credentials, personal data, or machine-specific absolute paths added
- [x] Docs updated if behavior, flags, or the permission/trust model changed — N/A

## Verification

| environment | result |
|---|---|
| `env -u DISPLAY -u WAYLAND_DISPLAY` | `skipped: no DISPLAY or WAYLAND_DISPLAY`, exit 0 |
| `DISPLAY= WAYLAND_DISPLAY=` (empty) | same skip, exit 0 |
| desktop session (`DISPLAY=:0`) | `non-headless mcp viewer smoke passed`, exit 0 |

The empty-string case is the one worth pinning: `host_display_check()` filters empty vars, so a set-but-empty `DISPLAY` is not a host display, and the guard has to agree with it.