### PR TITLE
release: v0.3.2 — MCP 2026-07-28 tools/list cache metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,7 +121,7 @@ dependencies = [
 
 [[package]]
 name = "agent-workspace-linux"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "gpui",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-workspace-linux"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 license = "MIT"
 description = "Isolated Linux desktop workspaces for AI agents."

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-sh/agent-workspace-linux",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Isolated Linux desktop workspaces for AI agents — MCP server binary wrapper.",
   "license": "MIT",
   "publishConfig": {


### PR DESCRIPTION
## Summary

Cuts 0.3.2 so the #68 fix reaches installed users. 0.3.1 omitted the SEP-2549 `ttlMs` and `cacheScope` fields from `tools/list`, which the 2026-07-28 spec requires — hosts negotiating that version, Claude Code 2.1.234 among them, reject tool discovery outright, so an installed 0.3.1 advertises **no tools at all** to them.

Ships #69. Version-only change: `Cargo.toml`, `Cargo.lock`, `npm/package.json`, same three-line shape as the v0.3.1 bump (96f7f30).

## Checklist

- [x] `cargo fmt --check` passes
- [x] `cargo clippy --locked -- -D warnings` passes
- [x] `cargo test --locked` passes (180 tests)
- [x] `git diff --check` is clean
- [x] `scripts/integration_smoke.sh` — N/A, no behavior change in this commit; the shipped fix was smoke-verified on #69
- [x] No secrets, credentials, personal data, or machine-specific absolute paths added
- [x] Docs updated if behavior, flags, or the permission/trust model changed — N/A

## Verification

Ran what CI runs, plus the release-specific gates:

| gate | result |
|---|---|
| `cargo fmt --check` | pass |
| `cargo build --locked` | 0.3.2 builds |
| `cargo clippy --locked -- -D warnings` | pass |
| `cargo test --locked` | 180 passed |
| `scripts/install_smoke.sh` | `installer smoke ok` (release profile) |
| `node --check` over `scripts/`, `npm/` | pass |
| `node --test npm/scripts/postinstall.test.js` | 0 fail |
| version parity Cargo ↔ npm | `0.3.2 == 0.3.2` |
| `npm pack --dry-run` | `agent-sh-agent-workspace-linux-0.3.2.tgz`, 4 files |

## After merge

Tag `v0.3.2` on the merge commit and push it. That builds both targets, attaches the binaries with their `.sha256` sidecars, then publishes the npm wrapper with the version stamped from the tag.