### PR TITLE
chore(ci): synchronize CodeQL action updates

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -54,7 +54,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
+        uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
@@ -62,6 +62,6 @@ jobs:
           queries: security-extended
 
       - name: Analyze
-        uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
+        uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Summary

- update both CodeQL init and analyze actions to the same v4.37.9 commit
- cover Dependabot PRs #81 and #82, which independently updated only one half of the pair and left CodeQL/revuto checks failing

## Verification

- `cargo fmt --check`
- `cargo clippy --locked -- -D warnings`
- `cargo test --locked`
- `git diff --check`

Closes #81
Closes #82